### PR TITLE
No visual filter on react athletes

### DIFF
--- a/apps/react-app/src/App.tsx
+++ b/apps/react-app/src/App.tsx
@@ -47,7 +47,6 @@ const athleteSelections: SelectionConfig[] = [
       include: [
         'athlete_external_filter', // Includes menus and brush
         'athlete_rowSelection',
-        'athlete_internal_filter'
       ] 
     } 
   },


### PR DESCRIPTION
I made this pull request to demonstrate how to turn off the tanstack internal filter from changing the visual on the athletes dashboard. This is done by simply taking out the internal filter selection from the include array for our athletes visual.