### PR TITLE
ci: dependabot upgrades only for MINOR and PATCH

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,5 +16,11 @@ updates:
     groups:
       dev-deps:
         dependency-type: 'development'
+        update-types:
+          - patch
+          - minor
       prod-deps:
         dependency-type: 'production'
+        update-types:
+          - patch
+          - minor


### PR DESCRIPTION
currently, the dependabot config allows for any type, including MAJOR upgrades, which we want to avoid, since these often include breaking changes.

this commit updates the dependabot config to limit upgrades to only MINOR and PATCH types for both
development and production dependencies.