### PR TITLE
dependabot.yaml: add quarterly major updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,3 +24,17 @@ updates:
         update-types:
           - patch
           - minor
+
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: quarterly
+    groups:
+      dev-deps:
+        dependency-type: 'development'
+        update-types:
+          - major
+      prod-deps:
+        dependency-type: 'production'
+        update-types:
+          - major


### PR DESCRIPTION
I think it makes sense to get some kind of notification for major updates. I was thinking quarterly or semi-annually. If you think this will be too noisy, we can close it.