### PR TITLE
fix(release): correct react-table package version

### DIFF
--- a/examples/react/trimmed/CHANGELOG.md
+++ b/examples/react/trimmed/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - Updated dependencies [[`82ca7ff`](https://github.com/nozzle/mosaic-adapters/commit/82ca7ff9c0c558ee7e0b80b5b59eff6f8f5238ef)]:
-  - @nozzleio/mosaic-tanstack-react-table@1.0.0
+  - @nozzleio/mosaic-tanstack-react-table@0.1.0
   - @nozzleio/react-mosaic@0.1.0
 
 ## 0.0.2

--- a/packages/mosaic-tanstack-react-table/CHANGELOG.md
+++ b/packages/mosaic-tanstack-react-table/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @nozzleio/mosaic-tanstack-react-table
 
-## 1.0.0
+## 0.1.0
 
 ### Minor Changes
 

--- a/packages/mosaic-tanstack-react-table/package.json
+++ b/packages/mosaic-tanstack-react-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozzleio/mosaic-tanstack-react-table",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "React bindings for the Mosaic TanStack table adapter.",
   "license": "MIT",
   "type": "module",
@@ -67,7 +67,7 @@
     "@uwdata/mosaic-core": "catalog:"
   },
   "peerDependencies": {
-    "@nozzleio/react-mosaic": "workspace:*",
+    "@nozzleio/react-mosaic": ">=0.1.0 <1",
     "@tanstack/react-table": ">=8.17.3",
     "react": ">=19.2.4",
     "react-dom": ">=19.2.4"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,3 @@
-cleanupUnusedCatalogs: true
-linkWorkspacePackages: true
-preferWorkspacePackages: true
-
 packages:
   - packages/*
   - examples/react/*
@@ -10,29 +6,30 @@ catalog:
   '@eslint-react/eslint-plugin': ^3.0.0
   '@playwright/test': ^1.57.0
   '@tanstack/eslint-config': ^0.4.0
-  '@tanstack/vite-config': ^0.5.2
-  '@tanstack/store': ^0.9.1
   '@tanstack/react-store': ^0.9.1
+  '@tanstack/store': ^0.9.1
   '@tanstack/table-core': ^8.17.3
-  '@types/cors': ^2.8.17
-  '@types/express': ^5.0.0
+  '@tanstack/vite-config': ^0.5.2
   '@types/node': ^25.0.8
   '@uwdata/mosaic-core': ^0.21.1
   '@uwdata/mosaic-sql': ^0.21.1
   '@uwdata/vgplot': ^0.21.1
   '@vitejs/plugin-react': ^6.0.1
-  cors: 2.8.6
   eslint: ^10.1.0
   eslint-plugin-react-hooks: ^7.0.1
   eslint-plugin-unused-imports: ^4.3.0
-  express: 4.22.1
   jsdom: ^27.4.0
-  node-fetch: 3.3.2
   rimraf: ^6.1.0
   typescript: ^5.9.3
   typescript-eslint: ^8.46.2
   vite: ^8.0.2
   vitest: ^4.1.1
 
+cleanupUnusedCatalogs: true
+
+linkWorkspacePackages: true
+
 onlyBuiltDependencies:
   - esbuild
+
+preferWorkspacePackages: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+cleanupUnusedCatalogs: true
+linkWorkspacePackages: true
+preferWorkspacePackages: true
+
 packages:
   - packages/*
   - examples/react/*


### PR DESCRIPTION
## Summary
- correct `@nozzleio/mosaic-tanstack-react-table` from `1.0.0` back to `0.1.0` in-repo
- fix the generated changelog entries that referenced the mistaken major release
- widen the `@nozzleio/react-mosaic` peer range so internal pre-1.0 minor bumps do not force a major release

## Validation
- `pnpm test:types`
- `pnpm test:lint`
- `pnpm test:build`

## npm cleanup notes
- attempted `npm unpublish @nozzleio/mosaic-tanstack-react-table@1.0.0`; the command exited without an error but registry metadata continued to show `1.0.0`
- attempted `npm deprecate @nozzleio/mosaic-tanstack-react-table@1.0.0 "Published in error; use 0.1.0 once it is released."`; npm returned `E404`, which may indicate the unpublish partially took effect or the current auth context cannot mutate that package metadata reliably
