### PR TITLE
Improve Nozzle Report summary selection visibility and active filter handling

### DIFF
--- a/.changeset/five-turtles-sort.md
+++ b/.changeset/five-turtles-sort.md
@@ -1,0 +1,5 @@
+---
+'@nozzleio/mosaic-tanstack-react-table': minor
+---
+
+feat(react-mosaic): add source-scoped selection value reads

--- a/.changeset/spotty-donkeys-thank.md
+++ b/.changeset/spotty-donkeys-thank.md
@@ -1,0 +1,6 @@
+---
+'@nozzleio/mosaic-tanstack-react-table': minor
+'@nozzleio/mosaic-tanstack-table-core': minor
+---
+
+feat(table-core,react-table): support removable active chips for row-selection arrays

--- a/docs/core/concepts.md
+++ b/docs/core/concepts.md
@@ -229,6 +229,13 @@ useRegisterFilterSource($domainFilter, 'global', {
   labelMap: { domain: 'Domain' },
 });
 
+// For row-selection-backed multi-select filters, expose one removable
+// chip per selected scalar value.
+useRegisterFilterSource($summarySelection, 'summary', {
+  labelMap: { phrase: 'Selected Keyword' },
+  explodeArrayValues: true,
+});
+
 function ActiveFilterBar() {
   const filters = useActiveFilters();
   const registry = useFilterRegistry();

--- a/docs/react/complex-setup.md
+++ b/docs/react/complex-setup.md
@@ -479,3 +479,14 @@ vg.dot(vg.from('data', { filterBy: $hover }), {
 - [Data Flow](../core/data-flow.md) – Deep dive into query lifecycle
 - [Concepts](../core/concepts.md) – Review core primitives
 - [Grouped Table](./grouped-table.md) – Server-side hierarchical grouping with lazy expand
+For summary selections that also appear in an active-filter bar, register them with `explodeArrayValues: true` so each selected row value becomes its own removable chip:
+
+```tsx
+useRegisterFilterSource($phraseSelection, 'summary', {
+  labelMap: { phrase: 'Selected Keyword' },
+  explodeArrayValues: true,
+});
+```
+
+For row-selection-backed summary filters, use `explodeArrayValues: true` during registration so the bar shows one chip per selected scalar value and removing one chip rebuilds the remaining predicate instead of clearing the whole selection.
+

--- a/docs/react/complex-setup.md
+++ b/docs/react/complex-setup.md
@@ -490,3 +490,14 @@ useRegisterFilterSource($phraseSelection, 'summary', {
 
 For row-selection-backed summary filters, use `explodeArrayValues: true` during registration so the bar shows one chip per selected scalar value and removing one chip rebuilds the remaining predicate instead of clearing the whole selection.
 
+## Client-Scoped Selection UI
+
+Some complex dashboards need to show selection state for one specific table client, not the shared global selection snapshot. Use `useMosaicSelectionValue(selection, { source: client })` for that case:
+
+```tsx
+const selectedValues = useMosaicSelectionValue<string[]>(selection, {
+  source: client,
+});
+```
+
+This is the pattern used by the Nozzle PAA summary cards to keep a local `Selected (N)` strip visible even when peer cross-filtering removes those rows from the current table body.

--- a/docs/react/complex-setup.md
+++ b/docs/react/complex-setup.md
@@ -243,6 +243,15 @@ const { tableOptions } = useMosaicReactTable<GroupByRow>({
 
 When users select rows, the adapter updates `$phraseSelection` with predicates like `phrase IN ('value1', 'value2')`.
 
+For summary selections that also appear in an active-filter bar, register them with `explodeArrayValues: true` so each selected row value becomes its own removable chip:
+
+```tsx
+useRegisterFilterSource($phraseSelection, 'summary', {
+  labelMap: { phrase: 'Selected Keyword' },
+  explodeArrayValues: true,
+});
+```
+
 ## Total Rows Modes
 
 Large tables often need a reliable total row count. The adapter supports two strategies:
@@ -319,6 +328,8 @@ const { tableOptions } = useMosaicReactTable({
 Then style rows based on the hidden `__is_highlighted` column.
 
 This pattern is used in `examples/react/trimmed/src/components/views/nozzle-paa.tsx` to keep summary tables highlighted without filtering out rows.
+
+One subtle consequence of this topology is that a peer summary table can still narrow the visible rows in the current summary table. If users need to remove selections that are no longer visible in the table body, add a local selected-values strip outside the table body rather than relying only on row visibility.
 
 ## Global Reset
 
@@ -404,6 +415,20 @@ function ActiveFilterBar() {
 
 For a full version (group registration, labels, and UI), see `examples/react/trimmed/src/components/views/nozzle-paa.tsx` and `examples/react/trimmed/src/components/active-filter-bar.tsx`.
 
+For row-selection-backed summary filters, use `explodeArrayValues: true` during registration so the bar shows one chip per selected scalar value and removing one chip rebuilds the remaining predicate instead of clearing the whole selection.
+
+## Client-Scoped Selection UI
+
+Some complex dashboards need to show selection state for one specific table client, not the shared global selection snapshot. Use `useMosaicSelectionValue(selection, { source: client })` for that case:
+
+```tsx
+const selectedValues = useMosaicSelectionValue<string[]>(selection, {
+  source: client,
+});
+```
+
+This is the pattern used by the Nozzle PAA summary cards to keep a local `Selected (N)` strip visible even when peer cross-filtering removes those rows from the current table body.
+
 ## KPI Queries (Value Helpers)
 
 For KPIs, use a query factory + `useMosaicValue` to return a single value that respects a filter context:
@@ -479,25 +504,3 @@ vg.dot(vg.from('data', { filterBy: $hover }), {
 - [Data Flow](../core/data-flow.md) – Deep dive into query lifecycle
 - [Concepts](../core/concepts.md) – Review core primitives
 - [Grouped Table](./grouped-table.md) – Server-side hierarchical grouping with lazy expand
-For summary selections that also appear in an active-filter bar, register them with `explodeArrayValues: true` so each selected row value becomes its own removable chip:
-
-```tsx
-useRegisterFilterSource($phraseSelection, 'summary', {
-  labelMap: { phrase: 'Selected Keyword' },
-  explodeArrayValues: true,
-});
-```
-
-For row-selection-backed summary filters, use `explodeArrayValues: true` during registration so the bar shows one chip per selected scalar value and removing one chip rebuilds the remaining predicate instead of clearing the whole selection.
-
-## Client-Scoped Selection UI
-
-Some complex dashboards need to show selection state for one specific table client, not the shared global selection snapshot. Use `useMosaicSelectionValue(selection, { source: client })` for that case:
-
-```tsx
-const selectedValues = useMosaicSelectionValue<string[]>(selection, {
-  source: client,
-});
-```
-
-This is the pattern used by the Nozzle PAA summary cards to keep a local `Selected (N)` strip visible even when peer cross-filtering removes those rows from the current table body.

--- a/docs/react/inputs.md
+++ b/docs/react/inputs.md
@@ -505,6 +505,16 @@ const selectionValue = useMosaicSelectionValue<[number, number]>(selection);
 
 This avoids manual event listeners and keeps the UI in sync with global resets.
 
+If a component needs the value for one specific Mosaic client instead of the shared selection snapshot, pass a `source` option:
+
+```tsx
+const scopedValue = useMosaicSelectionValue<string[]>(selection, {
+  source: client,
+});
+```
+
+This reads `selection.valueFor(client)` and normalizes missing values to `null`, which is useful for client-local UI such as summary-card selection strips.
+
 ## Row Selection (Summary Tables)
 
 Summary tables often act as filters. Use `rowSelection` to write a selection based on row clicks:
@@ -527,6 +537,15 @@ const { tableOptions } = useMosaicReactTable<GroupByRow>({
 
 See `examples/react/trimmed/src/components/views/nozzle-paa.tsx` for the full summary table pattern.
 
+If you surface summary selections in an active-filter bar, register the selection with `explodeArrayValues: true` so multi-select row picks render as separate removable chips instead of one combined value:
+
+```tsx
+useRegisterFilterSource($summarySelection, 'summary', {
+  labelMap: { key: 'Selected Keyword' },
+  explodeArrayValues: true,
+});
+```
+
 ## Complete Examples
 
 - **Searchable select**: `examples/react/trimmed/src/components/paa/paa-filters.tsx` (`SearchableSelectFilter`)
@@ -541,22 +560,3 @@ See `examples/react/trimmed/src/components/views/nozzle-paa.tsx` for the full su
 - [Real-World Examples](./real-world-examples.md) – PAA and Athletes dashboards
 - [Data Flow](../core/data-flow.md) – How inputs propagate to queries
 - [Concepts](../core/concepts.md) – Review selections and contexts
-If you surface summary selections in an active-filter bar, register the selection with `explodeArrayValues: true` so multi-select row picks render as separate removable chips instead of one combined value:
-
-```tsx
-useRegisterFilterSource($summarySelection, 'summary', {
-  labelMap: { key: 'Selected Keyword' },
-  explodeArrayValues: true,
-});
-```
-
-If a component needs the value for one specific Mosaic client instead of the shared selection snapshot, pass a `source` option:
-
-```tsx
-const scopedValue = useMosaicSelectionValue<string[]>(selection, {
-  source: client,
-});
-```
-
-This reads `selection.valueFor(client)` and normalizes missing values to `null`, which is useful for client-local UI such as summary-card selection strips.
-

--- a/docs/react/inputs.md
+++ b/docs/react/inputs.md
@@ -550,3 +550,13 @@ useRegisterFilterSource($summarySelection, 'summary', {
 });
 ```
 
+If a component needs the value for one specific Mosaic client instead of the shared selection snapshot, pass a `source` option:
+
+```tsx
+const scopedValue = useMosaicSelectionValue<string[]>(selection, {
+  source: client,
+});
+```
+
+This reads `selection.valueFor(client)` and normalizes missing values to `null`, which is useful for client-local UI such as summary-card selection strips.
+

--- a/docs/react/inputs.md
+++ b/docs/react/inputs.md
@@ -541,3 +541,12 @@ See `examples/react/trimmed/src/components/views/nozzle-paa.tsx` for the full su
 - [Real-World Examples](./real-world-examples.md) – PAA and Athletes dashboards
 - [Data Flow](../core/data-flow.md) – How inputs propagate to queries
 - [Concepts](../core/concepts.md) – Review selections and contexts
+If you surface summary selections in an active-filter bar, register the selection with `explodeArrayValues: true` so multi-select row picks render as separate removable chips instead of one combined value:
+
+```tsx
+useRegisterFilterSource($summarySelection, 'summary', {
+  labelMap: { key: 'Selected Keyword' },
+  explodeArrayValues: true,
+});
+```
+

--- a/docs/react/real-world-examples.md
+++ b/docs/react/real-world-examples.md
@@ -26,6 +26,8 @@ These examples are the fastest way to see how the libraries are used in practice
 - KPI queries using `useMosaicValue`
 - Active filter bar + global reset
 - Summary tables using `rowSelection` + `manualHighlight`
+- Summary selections registered as individually removable active-filter chips
+- Per-card `Selected (N)` strips keep hidden summary selections visible and removable
 
 ## Athletes (Grouped Table)
 

--- a/examples/react/trimmed/src/components/views/nozzle-paa.tsx
+++ b/examples/react/trimmed/src/components/views/nozzle-paa.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import * as mSql from '@uwdata/mosaic-sql';
 import { useReactTable } from '@tanstack/react-table';
+import { X } from 'lucide-react';
 import {
   useFilterRegistry,
   useMosaicReactTable,
@@ -15,7 +16,11 @@ import {
   createMosaicColumnHelper,
   createMosaicMapping,
 } from '@nozzleio/mosaic-tanstack-react-table/helpers';
-import { useConnectorStatus, useCoordinator } from '@nozzleio/react-mosaic';
+import {
+  useConnectorStatus,
+  useCoordinator,
+  useMosaicSelectionValue,
+} from '@nozzleio/react-mosaic';
 import type { ColumnDef } from '@tanstack/react-table';
 import type { AggregateNode, FilterExpr } from '@uwdata/mosaic-sql';
 import type { Selection } from '@uwdata/mosaic-core';
@@ -31,6 +36,7 @@ import {
 } from '@/components/paa/paa-filters';
 import { SparklineCell } from '@/components/paa/sparkline';
 import { ActiveFilterBar } from '@/components/active-filter-bar';
+import { Button } from '@/components/ui/button';
 
 const TABLE_NAME = 'nozzle_paa';
 
@@ -140,15 +146,19 @@ export function NozzlePaaView() {
   // Register Summary Table Output Selections
   useRegisterFilterSource(topology.selections.phrase, 'summary', {
     labelMap: { phrase: 'Selected Keyword' },
+    explodeArrayValues: true,
   });
   useRegisterFilterSource(topology.selections.question, 'summary', {
     labelMap: { 'related_phrase.phrase': 'Selected Question' },
+    explodeArrayValues: true,
   });
   useRegisterFilterSource(topology.selections.domain, 'summary', {
     labelMap: { domain: 'Selected Domain' },
+    explodeArrayValues: true,
   });
   useRegisterFilterSource(topology.selections.url, 'summary', {
     labelMap: { url: 'Selected URL' },
+    explodeArrayValues: true,
   });
 
   // Register Detail Table Column Filters
@@ -417,6 +427,35 @@ function KpiCard({ label, value }: { label: string; value: string | number }) {
 
 type AggregationFactory = (expression?: any) => AggregateNode;
 
+function getGroupByExpression(groupBy: string) {
+  if (groupBy.includes('.')) {
+    const [col, field] = groupBy.split('.');
+    return mSql.sql`${mSql.column(col!)}.${mSql.sql([field!] as any)}`;
+  }
+
+  return mSql.column(groupBy);
+}
+
+function buildSummarySelectionPredicate(
+  groupBy: string,
+  values: Array<string | number>,
+): ReturnType<typeof mSql.eq> | ReturnType<typeof mSql.isIn> | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const columnExpr = getGroupByExpression(groupBy);
+
+  if (values.length === 1) {
+    return mSql.eq(columnExpr, mSql.literal(values[0]));
+  }
+
+  return mSql.isIn(
+    columnExpr,
+    values.map((value) => mSql.literal(value)),
+  );
+}
+
 function SummaryTable({
   title,
   groupBy,
@@ -442,13 +481,7 @@ function SummaryTable({
 }) {
   const queryFactory = useMemo(
     () => (filter: FilterExpr | null | undefined) => {
-      let groupKey;
-      if (groupBy.includes('.')) {
-        const [col, field] = groupBy.split('.');
-        groupKey = mSql.sql`${mSql.column(col!)}.${mSql.sql([field!] as any)}`;
-      } else {
-        groupKey = mSql.column(groupBy);
-      }
+      const groupKey = getGroupByExpression(groupBy);
 
       const highlightPred = selection.predicate(null);
       let highlightCol;
@@ -554,7 +587,7 @@ function SummaryTable({
     [groupBy, title, metricLabel, helper, sparkline, filterBy, enabled],
   );
 
-  const { tableOptions } = useMosaicReactTable<GroupByRow>({
+  const { tableOptions, client } = useMosaicReactTable<GroupByRow>({
     table: queryFactory,
     filterBy: filterBy,
     manualHighlight: true,
@@ -586,13 +619,82 @@ function SummaryTable({
     enabled,
   });
 
+  const selectedValue = useMosaicSelectionValue<
+    Array<string | number> | string | number | null
+  >(selection, {
+    source: client,
+  });
+  const selectedValues = useMemo(() => {
+    if (selectedValue === null) {
+      return [] as Array<string | number>;
+    }
+
+    return Array.isArray(selectedValue) ? selectedValue : [selectedValue];
+  }, [selectedValue]);
+
   const table = useReactTable(tableOptions);
 
+  const updateSelectionValues = (nextValues: Array<string | number>) => {
+    selection.update({
+      source: client,
+      clients: new Set([client]),
+      value: nextValues.length > 0 ? nextValues : null,
+      predicate: buildSummarySelectionPredicate(groupBy, nextValues),
+    });
+  };
+
+  const clearSelection = () => {
+    updateSelectionValues([]);
+  };
+
+  const removeSelectedValue = (valueToRemove: string | number) => {
+    const nextValues = selectedValues.filter(
+      (value) => !Object.is(value, valueToRemove),
+    );
+    updateSelectionValues(nextValues);
+  };
+
   return (
-    <div className="bg-white border rounded-lg shadow-sm flex flex-col h-[350px] overflow-hidden">
+    <div className="bg-white border rounded-lg shadow-sm flex flex-col h-[700px] overflow-hidden">
       <div className="px-4 py-3 border-b bg-slate-50 text-sm font-bold text-slate-700 uppercase tracking-wide">
         {title}
       </div>
+      {selectedValues.length > 0 ? (
+        <div className="px-4 py-3 border-b bg-blue-50/60 flex flex-wrap items-center gap-2">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-blue-900">
+            Selected ({selectedValues.length})
+          </div>
+          {selectedValues.map((value) => (
+            <div
+              key={String(value)}
+              className="flex items-center gap-1 rounded-full border border-blue-200 bg-white pl-2 pr-1 py-1 text-xs text-blue-900 shadow-sm"
+            >
+              <span className="max-w-[180px] truncate" title={String(value)}>
+                {String(value)}
+              </span>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-5 w-5 rounded-full text-blue-700 hover:bg-blue-100"
+                aria-label={`Remove ${title} selection ${String(value)}`}
+                onClick={() => removeSelectedValue(value)}
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </div>
+          ))}
+          <div className="flex-1" />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 text-xs text-blue-900 hover:bg-blue-100"
+            aria-label={`Clear ${title} selections`}
+            onClick={clearSelection}
+          >
+            Clear
+          </Button>
+        </div>
+      ) : null}
       <div className="flex-1 overflow-auto p-2">
         <RenderTable
           table={table}

--- a/examples/react/trimmed/tests/nozzle-paa.test.ts
+++ b/examples/react/trimmed/tests/nozzle-paa.test.ts
@@ -13,5 +13,48 @@ test.describe('nozzle-paa page', () => {
       name: 'Nozzle PAA Report',
     });
     await expect(heading).toBeVisible();
+    await expect(page.getByText(/^Selected \(\d+\)$/)).toHaveCount(0);
+    await expect(page.getByText('undefined')).toHaveCount(0);
+  });
+
+  test('keeps narrowed summary selections visible and removable outside the table body', async ({
+    page,
+  }) => {
+    await init(page);
+
+    const keywordTable = page.locator('table').nth(0);
+    const questionTable = page.locator('table').nth(1);
+
+    await keywordTable.locator('tbody tr').nth(0).click();
+    await keywordTable.locator('tbody tr').nth(1).click();
+
+    await questionTable.locator('tbody tr').nth(0).click();
+
+    await expect(page.getByText('unknown:')).toHaveCount(0);
+    await expect(page.getByText('Selected Keyword:').first()).toBeVisible();
+    await expect(page.getByText('Selected Question:').first()).toBeVisible();
+
+    await expect(
+      keywordTable.locator('tbody tr').filter({ hasText: 'gaz stove' }),
+    ).toHaveCount(0);
+
+    const hiddenSelectionButton = page.getByRole('button', {
+      name: 'Remove Keyword Phrase selection gaz stove',
+    });
+    await expect(hiddenSelectionButton).toBeVisible();
+
+    await hiddenSelectionButton.click();
+
+    await expect(hiddenSelectionButton).toHaveCount(0);
+    await expect(
+      page.getByRole('button', {
+        name: 'Remove Keyword Phrase selection gasoline stove',
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', {
+        name: 'Clear Keyword Phrase selections',
+      }),
+    ).toBeVisible();
   });
 });

--- a/packages/mosaic-tanstack-react-table/README.md
+++ b/packages/mosaic-tanstack-react-table/README.md
@@ -55,6 +55,7 @@ import { logger } from '@nozzleio/mosaic-tanstack-react-table/debug';
 ## Notes
 
 - `useFilterRegistry()` returns the narrowed React-facing action API, not the raw core `MosaicFilterRegistry` instance.
+- `useRegisterFilterSource()` accepts `explodeArrayValues: true` when a selection stores scalar arrays and the active-filter UI should expose them as individually removable chips.
 - `useMosaicTableFilter()` supports the runtime filter modes `TEXT`, `MATCH`, `SELECT`, `DATE_RANGE`, and `RANGE`.
 - `useMosaicTableFacetMenu()` exposes `toggle()`, `select()`, `clear()`, and `loadMore()`. Use `select()` for single-select facet UI and `clear()` to reset a facet.
 - This package does not re-export the full core package from the root. If you need headless-only APIs, import them from `@nozzleio/mosaic-tanstack-table-core` or its explicit subpaths.

--- a/packages/mosaic-tanstack-react-table/src/filter-registry.tsx
+++ b/packages/mosaic-tanstack-react-table/src/filter-registry.tsx
@@ -69,7 +69,8 @@ function areRegisterFilterSourceOptionsEqual(
 
   return (
     areRecordValuesEqual(previous.labelMap, next.labelMap) &&
-    areRecordValuesEqual(previous.formatterMap, next.formatterMap)
+    areRecordValuesEqual(previous.formatterMap, next.formatterMap) &&
+    previous.explodeArrayValues === next.explodeArrayValues
   );
 }
 

--- a/packages/mosaic-tanstack-react-table/tests/filter-registry.test.tsx
+++ b/packages/mosaic-tanstack-react-table/tests/filter-registry.test.tsx
@@ -98,4 +98,78 @@ describe('active filter hooks', () => {
 
     view.unmount();
   });
+
+  test('splits row-selection arrays into individually labeled active filters and removes them independently', async () => {
+    const phraseSelection = Selection.intersect();
+    let registry: ReturnType<typeof useFilterRegistry> | undefined;
+    let latestFilters: ReturnType<typeof useActiveFilters> = [];
+
+    function Probe() {
+      registry = useFilterRegistry();
+      latestFilters = useActiveFilters();
+
+      useRegisterFilterSource(phraseSelection, 'summary', {
+        labelMap: { phrase: 'Selected Keyword' },
+        explodeArrayValues: true,
+      });
+
+      React.useEffect(() => {
+        registry?.registerGroup({
+          id: 'summary',
+          label: 'Summary',
+          priority: 1,
+        });
+      }, [registry]);
+
+      return null;
+    }
+
+    const view = render(
+      <MosaicFilterProvider>
+        <Probe />
+      </MosaicFilterProvider>,
+    );
+    await flushEffects();
+
+    await act(async () => {
+      phraseSelection.update({
+        source: { rowSelectionColumn: 'phrase' } as never,
+        value: ['gasoline stove', 'gaz stove'],
+        predicate: {} as never,
+      });
+    });
+    await flushEffects();
+
+    expect(
+      latestFilters.map((filter) => ({
+        label: filter.label,
+        value: filter.value,
+      })),
+    ).toEqual([
+      { label: 'Selected Keyword', value: 'gasoline stove' },
+      { label: 'Selected Keyword', value: 'gaz stove' },
+    ]);
+
+    const gasFilter = latestFilters.find(
+      (filter) => filter.value === 'gasoline stove',
+    );
+    if (!gasFilter) {
+      throw new Error('Expected gasoline stove filter to be active.');
+    }
+
+    await act(async () => {
+      registry?.removeFilter(gasFilter);
+    });
+    await flushEffects();
+
+    expect(phraseSelection.value).toEqual(['gaz stove']);
+    expect(
+      latestFilters.map((filter) => ({
+        label: filter.label,
+        value: filter.value,
+      })),
+    ).toEqual([{ label: 'Selected Keyword', value: 'gaz stove' }]);
+
+    view.unmount();
+  });
 });

--- a/packages/mosaic-tanstack-table-core/src/data-table.ts
+++ b/packages/mosaic-tanstack-table-core/src/data-table.ts
@@ -84,6 +84,7 @@ export class MosaicDataTable<
   source: MosaicTableSource;
   schema: Array<FieldInfo> = [];
   tableFilterSelection: Selection = new Selection();
+  rowSelectionColumn?: string;
   options: MosaicDataTableOptions<TData, TValue>;
 
   #store: Store<MosaicDataTableStore<TData, TValue>> | null = null;
@@ -820,9 +821,11 @@ export class MosaicDataTable<
   #configureRowSelection(options: MosaicDataTableOptions<TData, TValue>): void {
     if (!options.rowSelection) {
       this.#rowSelectionManager = undefined;
+      this.rowSelectionColumn = undefined;
       return;
     }
 
+    this.rowSelectionColumn = options.rowSelection.column;
     this.#rowSelectionManager = new MosaicSelectionManager<string | number>({
       client: this,
       column: options.rowSelection.column,

--- a/packages/mosaic-tanstack-table-core/src/filter-registry.ts
+++ b/packages/mosaic-tanstack-table-core/src/filter-registry.ts
@@ -1,4 +1,7 @@
+import * as mSql from '@uwdata/mosaic-sql';
 import { Store } from '@tanstack/store';
+import { SqlIdentifier } from './domain/sql-identifier';
+import { createStructAccess } from './utils';
 import type {
   ClauseSource,
   Selection,
@@ -50,6 +53,26 @@ function resolveSourceId(sourceClient: ClauseSource | undefined): string {
   return 'unknown';
 }
 
+function buildScalarSelectionPredicate(
+  column: string,
+  values: Array<unknown>,
+): ReturnType<typeof mSql.eq> | ReturnType<typeof mSql.isIn> | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const columnExpr = createStructAccess(SqlIdentifier.from(column));
+
+  if (values.length === 1) {
+    return mSql.eq(columnExpr, mSql.literal(values[0]));
+  }
+
+  return mSql.isIn(
+    columnExpr,
+    values.map((value) => mSql.literal(value)),
+  );
+}
+
 /**
  * Configuration for a logical group of filters.
  * Used to sort the display of active filters in the UI.
@@ -70,6 +93,8 @@ export interface SelectionRegistration {
   labelMap?: Record<string, string>;
   /** Optional map to format values for specific source IDs */
   formatterMap?: Record<string, (val: unknown) => string>;
+  /** When true, scalar array values are shown as individually removable filters. */
+  explodeArrayValues?: boolean;
 }
 
 /**
@@ -160,6 +185,11 @@ export class MosaicFilterRegistry {
           Array.isArray(rawValue) &&
           rawValue.length > 0 &&
           isSelectionArrayItem(rawValue[0]);
+        const shouldExplodeArrayValues =
+          config.explodeArrayValues &&
+          Array.isArray(rawValue) &&
+          rawValue.length > 0 &&
+          !isSelectionArrayItem(rawValue[0]);
 
         if (isTanStackFilterArray) {
           rawValue.forEach((item) => {
@@ -174,6 +204,18 @@ export class MosaicFilterRegistry {
               selection,
               sourceClient,
               itemSourceId,
+            );
+          });
+        } else if (shouldExplodeArrayValues) {
+          rawValue.forEach((itemValue) => {
+            this.addActiveFilter(
+              allFilters,
+              config,
+              sourceId,
+              itemValue,
+              selection,
+              sourceClient,
+              sourceId,
             );
           });
         } else {
@@ -283,6 +325,20 @@ export class MosaicFilterRegistry {
         source: filter.sourceObject,
         value: nextVal,
         predicate: null,
+      });
+    } else if (
+      filter.subId &&
+      Array.isArray(filter.selection.value) &&
+      !filter.selection.value.every(isSelectionArrayItem)
+    ) {
+      const nextVal = filter.selection.value.filter(
+        (item) => !Object.is(item, filter.value),
+      );
+
+      filter.selection.update({
+        source: filter.sourceObject,
+        value: nextVal.length > 0 ? nextVal : null,
+        predicate: buildScalarSelectionPredicate(filter.sourceId, nextVal),
       });
     } else {
       // Standard clearing

--- a/packages/mosaic-tanstack-table-core/tests/data-table.test.ts
+++ b/packages/mosaic-tanstack-table-core/tests/data-table.test.ts
@@ -314,6 +314,7 @@ describe('MosaicDataTable characterization', () => {
       '2': true,
       '7': true,
     });
+    expect(client.rowSelectionColumn).toBe('id');
     expect(rowSelection.valueFor(client)).toEqual(['2', '7']);
     const rowSelectionPredicate = rowSelection.active.predicate;
     expect(rowSelectionPredicate).not.toBeNull();

--- a/packages/react-mosaic/README.md
+++ b/packages/react-mosaic/README.md
@@ -53,5 +53,6 @@ function App() {
 ## Notes
 
 - `useRequireMode()` returns a boolean readiness signal. Components that query immediately should still guard on that result before using coordinator-dependent clients.
+- `useMosaicSelectionValue(selection, { source })` can read a source-scoped selection snapshot when a component needs the value for a specific Mosaic client instead of the shared selection value.
 - `HttpArrowConnector` is exported from the package root for now even though it is not itself a React hook.
 - Table-specific active-filter helpers do not live here. Import `MosaicFilterProvider`, `useFilterRegistry`, `useActiveFilters`, and `useRegisterFilterSource` from `@nozzleio/mosaic-tanstack-react-table`.

--- a/packages/react-mosaic/src/hooks/use-mosaic-selection-value.ts
+++ b/packages/react-mosaic/src/hooks/use-mosaic-selection-value.ts
@@ -7,13 +7,36 @@
 import { useSyncExternalStore } from 'react';
 import type { Selection } from '@uwdata/mosaic-core';
 
-export function useMosaicSelectionValue<T>(selection: Selection): T | null {
+export interface UseMosaicSelectionValueOptions {
+  /**
+   * Optional scoped source/client. When provided, the hook reads the
+   * source-specific selection value via `selection.valueFor(source)`.
+   */
+  source?: unknown;
+}
+
+function readSelectionValue<T>(
+  selection: Selection,
+  options?: UseMosaicSelectionValueOptions,
+): T | null {
+  const rawValue =
+    options?.source !== undefined && options.source !== null
+      ? (selection.valueFor(options.source) as T | null | undefined)
+      : (selection.value as T | null | undefined);
+
+  return rawValue ?? null;
+}
+
+export function useMosaicSelectionValue<T>(
+  selection: Selection,
+  options?: UseMosaicSelectionValueOptions,
+): T | null {
   return useSyncExternalStore(
     (notify) => {
       selection.addEventListener('value', notify);
       return () => selection.removeEventListener('value', notify);
     },
-    () => selection.value as T | null,
-    () => selection.value as T | null,
+    () => readSelectionValue<T>(selection, options),
+    () => readSelectionValue<T>(selection, options),
   );
 }

--- a/packages/react-mosaic/tests/hooks-and-registry.test.tsx
+++ b/packages/react-mosaic/tests/hooks-and-registry.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, expect, test, vi } from 'vitest';
-import { Selection, clausePoint } from '@uwdata/mosaic-core';
+import { MosaicClient, Selection, clausePoint } from '@uwdata/mosaic-core';
 
 import { useMosaicSelectionValue } from '../src/hooks/use-mosaic-selection-value';
 import {
@@ -27,6 +27,12 @@ function updateSelection(
   );
 }
 
+class TestClient extends MosaicClient {
+  override query() {
+    return null;
+  }
+}
+
 describe('selection hooks', () => {
   test('useMosaicSelectionValue switches snapshots when the selection instance changes', async () => {
     const first = Selection.intersect();
@@ -48,6 +54,35 @@ describe('selection hooks', () => {
     await flushEffects();
 
     expect(values.at(-1)).toBe('second');
+
+    view.unmount();
+  });
+
+  test('useMosaicSelectionValue reads a source-scoped snapshot when provided', async () => {
+    const selection = Selection.intersect();
+    const firstSource = new TestClient();
+    const secondSource = new TestClient();
+    const values: Array<string | null> = [];
+
+    selection.update(
+      clausePoint('value', 'first-scoped', { source: firstSource }),
+    );
+    selection.update(
+      clausePoint('value', 'second-scoped', { source: secondSource }),
+    );
+    await flushEffects();
+
+    function Probe({ source }: { source: MosaicClient }) {
+      const value = useMosaicSelectionValue<string>(selection, { source });
+      values.push(value);
+      return null;
+    }
+
+    const view = render(<Probe source={firstSource} />);
+    view.rerender(<Probe source={secondSource} />);
+    await flushEffects();
+
+    expect(values.at(-1)).toBe('second-scoped');
 
     view.unmount();
   });


### PR DESCRIPTION
This PR improves the Nozzle PAA summary-selection flow and the supporting APIs behind it.

- row-selection summary filters now show up as properly labeled, individually removable chips
- `useMosaicSelectionValue` can now read a value scoped to a specific source/client
- the Nozzle example keeps selected summary values visible and removable even when cross-filtering hides them from the table body
- the related React docs were updated to match the new behavior