### PR TITLE
chore(root): correct changeset for source-scoped selection value reads

### DIFF
--- a/.changeset/five-turtles-sort.md
+++ b/.changeset/five-turtles-sort.md
@@ -1,5 +1,5 @@
 ---
-'@nozzleio/mosaic-tanstack-react-table': minor
+'@nozzleio/react-mosaic': minor
 ---
 
 feat(react-mosaic): add source-scoped selection value reads


### PR DESCRIPTION
Correct the changeset for the source-scoped selection value reads change.

Update the changeset file so the release metadata matches the intended package change.