### PR TITLE
Preserve table row selection across fullscreen/remounts and add trimmed example coverage

### DIFF
--- a/.changeset/tired-phones-send.md
+++ b/.changeset/tired-phones-send.md
@@ -1,0 +1,26 @@
+---
+'@nozzleio/mosaic-tanstack-table-core': patch
+---
+
+fix(table-core): preserve row selection across remounted table clients
+
+Restore TanStack rowSelection from the shared Mosaic Selection value instead
+of only the current client-scoped value.
+
+Before this change, row selection UI was hydrated from
+selection.valueFor(client). That worked while the same table instance stayed
+mounted, but failed when a table was unmounted and remounted as a different
+client, such as when moving a widget into or out of fullscreen. In that
+case, crossfiltering and predicates remained active, but the new table
+instance lost its visual row-selection state because it had no source-scoped
+selection value of its own.
+
+This change adds shared selection hydration in the selection manager and uses
+it when syncing rowSelection back into table state. That keeps visual row
+selection consistent across multiple mounted clients and across remounts while
+preserving the existing source-scoped update behavior for writes.
+
+Also adds regression coverage for:
+
+- hydrating row selection into a remounted client
+- keeping row selection visuals in sync across two clients sharing one selection

--- a/examples/react/trimmed/src/components/views/nozzle-paa.tsx
+++ b/examples/react/trimmed/src/components/views/nozzle-paa.tsx
@@ -5,7 +5,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import * as mSql from '@uwdata/mosaic-sql';
 import { useReactTable } from '@tanstack/react-table';
-import { X } from 'lucide-react';
+import { ArrowDownLeft, ArrowUpRight, X } from 'lucide-react';
 import {
   useFilterRegistry,
   useMosaicReactTable,
@@ -76,6 +76,8 @@ interface GroupByRow {
   __is_highlighted?: number;
 }
 
+type SummaryTableId = 'phrase' | 'question' | 'domain' | 'url';
+
 const GroupByMapping = createMosaicMapping<GroupByRow>({
   key: { sqlColumn: 'key', type: 'VARCHAR', filterType: 'EQUALS' },
   metric: { sqlColumn: 'metric', type: 'INTEGER', filterType: 'RANGE' },
@@ -89,6 +91,9 @@ const GroupByMapping = createMosaicMapping<GroupByRow>({
 export function NozzlePaaView() {
   const [isReady, setIsReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [expandedTableId, setExpandedTableId] = useState<SummaryTableId | null>(
+    null,
+  );
   const coordinator = useCoordinator();
   const { mode } = useConnectorStatus();
   const topology = usePaaTopology();
@@ -100,6 +105,61 @@ export function NozzlePaaView() {
   // Stable Where Clauses
   const whereDomain = useMemo(() => mSql.sql`domain IS NOT NULL`, []);
   const whereUrl = useMemo(() => mSql.sql`url IS NOT NULL`, []);
+  const summaryTables = useMemo(
+    () =>
+      [
+        {
+          id: 'phrase',
+          title: 'Keyword Phrase',
+          groupBy: 'phrase',
+          metric: 'search_volume',
+          metricLabel: 'Search Vol',
+          aggFn: maxAgg,
+          sparkline: {
+            metric: 'search_volume',
+            dateColumn: 'requested',
+            aggMode: 'max',
+          } satisfies SparklineCellConfig,
+          filterBy: topology.phraseContext,
+          selection: topology.selections.phrase,
+        },
+        {
+          id: 'question',
+          title: 'PAA Questions',
+          groupBy: 'related_phrase.phrase',
+          metric: '*',
+          metricLabel: 'SERP Appears',
+          aggFn: mSql.count,
+          filterBy: topology.questionContext,
+          selection: topology.selections.question,
+        },
+        {
+          id: 'domain',
+          title: 'Domain',
+          groupBy: 'domain',
+          metric: '*',
+          metricLabel: '# of Answers',
+          aggFn: mSql.count,
+          where: whereDomain,
+          filterBy: topology.domainContext,
+          selection: topology.selections.domain,
+        },
+        {
+          id: 'url',
+          title: 'URL',
+          groupBy: 'url',
+          metric: '*',
+          metricLabel: '# of Answers',
+          aggFn: mSql.count,
+          where: whereUrl,
+          filterBy: topology.urlContext,
+          selection: topology.selections.url,
+        },
+      ] satisfies Array<SummaryTableConfig>,
+    [maxAgg, topology, whereDomain, whereUrl],
+  );
+  const expandedTable =
+    summaryTables.find((table) => table.id === expandedTableId) ?? null;
 
   // Register Filter Groups on mount
   useEffect(() => {
@@ -298,54 +358,66 @@ export function NozzlePaaView() {
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-4 gap-6 px-6">
-        <SummaryTable
-          title="Keyword Phrase"
-          groupBy="phrase"
-          metric="search_volume"
-          metricLabel="Search Vol"
-          aggFn={maxAgg}
-          sparkline={{
-            metric: 'search_volume',
-            dateColumn: 'requested',
-            aggMode: 'max',
-          }}
-          filterBy={topology.phraseContext}
-          selection={topology.selections.phrase}
-          enabled={isReady}
-        />
-        <SummaryTable
-          title="PAA Questions"
-          groupBy="related_phrase.phrase"
-          metric="*"
-          metricLabel="SERP Appears"
-          aggFn={mSql.count}
-          filterBy={topology.questionContext}
-          selection={topology.selections.question}
-          enabled={isReady}
-        />
-        <SummaryTable
-          title="Domain"
-          groupBy="domain"
-          metric="*"
-          metricLabel="# of Answers"
-          aggFn={mSql.count}
-          where={whereDomain}
-          filterBy={topology.domainContext}
-          selection={topology.selections.domain}
-          enabled={isReady}
-        />
-        <SummaryTable
-          title="URL"
-          groupBy="url"
-          metric="*"
-          metricLabel="# of Answers"
-          aggFn={mSql.count}
-          where={whereUrl}
-          filterBy={topology.urlContext}
-          selection={topology.selections.url}
-          enabled={isReady}
-        />
+        {summaryTables.map((summaryTable) => {
+          if (summaryTable.id === expandedTableId) {
+            return (
+              <SummaryTablePlaceholder
+                key={summaryTable.id}
+                summaryId={summaryTable.id}
+                title={summaryTable.title}
+                onRestore={() => setExpandedTableId(null)}
+              />
+            );
+          }
+
+          return (
+            <SummaryTable
+              key={summaryTable.id}
+              summaryId={summaryTable.id}
+              {...summaryTable}
+              enabled={isReady}
+              heightClassName="h-[700px]"
+              promotionButton={
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-[11px] font-semibold"
+                  aria-label={`Enlarge ${summaryTable.title} table`}
+                  onClick={() => setExpandedTableId(summaryTable.id)}
+                >
+                  <ArrowUpRight className="h-3.5 w-3.5" />
+                  Enlarge
+                </Button>
+              }
+            />
+          );
+        })}
       </div>
+
+      {expandedTable ? (
+        <div className="px-6">
+          <SummaryTable
+            key={`${expandedTable.id}-expanded`}
+            summaryId={expandedTable.id}
+            {...expandedTable}
+            enabled={isReady}
+            heightClassName="h-[820px]"
+            promoted
+            promotionButton={
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 px-3 text-xs font-semibold"
+                aria-label={`Return ${expandedTable.title} table to grid`}
+                onClick={() => setExpandedTableId(null)}
+              >
+                <ArrowDownLeft className="h-3.5 w-3.5" />
+                Return to grid
+              </Button>
+            }
+          />
+        </div>
+      ) : null}
 
       <div className="flex-1 px-6 min-h-[500px]">
         <div className="bg-white border rounded-lg shadow-sm h-full flex flex-col overflow-hidden">
@@ -427,6 +499,19 @@ function KpiCard({ label, value }: { label: string; value: string | number }) {
 
 type AggregationFactory = (expression?: any) => AggregateNode;
 
+type SummaryTableConfig = {
+  id: SummaryTableId;
+  title: string;
+  groupBy: string;
+  metric: string;
+  metricLabel: string;
+  aggFn: AggregationFactory;
+  where?: FilterExpr;
+  filterBy: Selection;
+  selection: Selection;
+  sparkline?: SparklineCellConfig;
+};
+
 function getGroupByExpression(groupBy: string) {
   if (groupBy.includes('.')) {
     const [col, field] = groupBy.split('.');
@@ -457,6 +542,7 @@ function buildSummarySelectionPredicate(
 }
 
 function SummaryTable({
+  summaryId,
   title,
   groupBy,
   metric,
@@ -467,7 +553,11 @@ function SummaryTable({
   selection,
   enabled,
   sparkline,
+  heightClassName,
+  promotionButton,
+  promoted = false,
 }: {
+  summaryId: SummaryTableId;
   title: string;
   groupBy: string;
   metric: string;
@@ -478,6 +568,9 @@ function SummaryTable({
   selection: Selection;
   enabled: boolean;
   sparkline?: SparklineCellConfig;
+  heightClassName: string;
+  promotionButton?: React.ReactNode;
+  promoted?: boolean;
 }) {
   const queryFactory = useMemo(
     () => (filter: FilterExpr | null | undefined) => {
@@ -621,9 +714,7 @@ function SummaryTable({
 
   const selectedValue = useMosaicSelectionValue<
     Array<string | number> | string | number | null
-  >(selection, {
-    source: client,
-  });
+  >(selection);
   const selectedValues = useMemo(() => {
     if (selectedValue === null) {
       return [] as Array<string | number>;
@@ -655,9 +746,22 @@ function SummaryTable({
   };
 
   return (
-    <div className="bg-white border rounded-lg shadow-sm flex flex-col h-[700px] overflow-hidden">
-      <div className="px-4 py-3 border-b bg-slate-50 text-sm font-bold text-slate-700 uppercase tracking-wide">
-        {title}
+    <div
+      data-testid={`summary-table-${summaryId}${promoted ? '-expanded' : ''}`}
+      className={`bg-white border rounded-lg shadow-sm flex flex-col overflow-hidden ${heightClassName}`}
+    >
+      <div className="px-4 py-3 border-b bg-slate-50 flex items-center justify-between gap-3">
+        <div className="text-sm font-bold text-slate-700 uppercase tracking-wide">
+          {title}
+        </div>
+        <div className="flex items-center gap-2">
+          {promoted ? (
+            <span className="rounded-full bg-cyan-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-cyan-900">
+              Expanded view
+            </span>
+          ) : null}
+          {promotionButton}
+        </div>
       </div>
       {selectedValues.length > 0 ? (
         <div className="px-4 py-3 border-b bg-blue-50/60 flex flex-wrap items-center gap-2">
@@ -701,6 +805,49 @@ function SummaryTable({
           columns={tableOptions.columns}
           onRowClick={(row) => row.toggleSelected()}
         />
+      </div>
+    </div>
+  );
+}
+
+function SummaryTablePlaceholder({
+  summaryId,
+  title,
+  onRestore,
+}: {
+  summaryId: SummaryTableId;
+  title: string;
+  onRestore: () => void;
+}) {
+  return (
+    <div
+      data-testid={`summary-table-${summaryId}-placeholder`}
+      className="h-[700px] rounded-lg border border-dashed border-slate-300 bg-slate-100/70 p-6 flex flex-col justify-between"
+    >
+      <div className="space-y-3">
+        <div className="text-sm font-bold uppercase tracking-wide text-slate-700">
+          {title}
+        </div>
+        <div className="rounded-lg border border-slate-200 bg-white/90 p-4">
+          <div className="text-sm font-semibold text-slate-800">
+            This table is enlarged below
+          </div>
+          <p className="mt-2 text-sm text-slate-600 leading-6">
+            Use the expanded panel to verify that row highlighting survives
+            moving between regions of the page.
+          </p>
+        </div>
+      </div>
+      <div className="flex justify-end">
+        <Button
+          variant="outline"
+          size="sm"
+          aria-label={`Return ${title} table to grid`}
+          onClick={onRestore}
+        >
+          <ArrowDownLeft className="h-3.5 w-3.5" />
+          Return to grid
+        </Button>
       </div>
     </div>
   );

--- a/examples/react/trimmed/tests/nozzle-paa.test.ts
+++ b/examples/react/trimmed/tests/nozzle-paa.test.ts
@@ -57,4 +57,68 @@ test.describe('nozzle-paa page', () => {
       }),
     ).toBeVisible();
   });
+
+  test('preserves an existing summary selection when that table is enlarged', async ({
+    page,
+  }) => {
+    await init(page);
+
+    const domainCard = page.getByTestId('summary-table-domain');
+    await domainCard.locator('table tbody tr').nth(0).click();
+
+    await expect(
+      domainCard.getByRole('button', {
+        name: /Remove Domain selection /,
+      }),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: 'Enlarge Domain table' }).click();
+
+    const expandedDomainCard = page.getByTestId(
+      'summary-table-domain-expanded',
+    );
+    await expect(
+      page.getByTestId('summary-table-domain-placeholder'),
+    ).toBeVisible();
+    await expect(expandedDomainCard).toBeVisible();
+    await expect(
+      expandedDomainCard.getByRole('button', {
+        name: /Remove Domain selection /,
+      }),
+    ).toBeVisible();
+  });
+
+  test('preserves selections made while enlarged after returning the table to the grid', async ({
+    page,
+  }) => {
+    await init(page);
+
+    await page.getByRole('button', { name: 'Enlarge Domain table' }).click();
+
+    const expandedDomainCard = page.getByTestId(
+      'summary-table-domain-expanded',
+    );
+    await expandedDomainCard.locator('table tbody tr').nth(0).click();
+
+    await expect(
+      expandedDomainCard.getByRole('button', {
+        name: /Remove Domain selection /,
+      }),
+    ).toBeVisible();
+
+    await expandedDomainCard
+      .getByRole('button', { name: 'Return Domain table to grid' })
+      .click();
+
+    const gridDomainCard = page.getByTestId('summary-table-domain');
+    await expect(gridDomainCard).toBeVisible();
+    await expect(
+      page.getByTestId('summary-table-domain-placeholder'),
+    ).toHaveCount(0);
+    await expect(
+      gridDomainCard.getByRole('button', {
+        name: /Remove Domain selection /,
+      }),
+    ).toBeVisible();
+  });
 });

--- a/examples/react/trimmed/vite.config.ts
+++ b/examples/react/trimmed/vite.config.ts
@@ -8,14 +8,6 @@ export default defineConfig({
     tsconfigPaths: true,
   },
   plugins: [react(), tailwindcss()],
-  optimizeDeps: {
-    // Exclude workspace packages from pre-bundling to ensure changes are picked up immediately
-    exclude: [
-      '@nozzleio/react-mosaic',
-      '@nozzleio/mosaic-tanstack-react-table',
-      '@nozzleio/mosaic-tanstack-table-core',
-    ],
-  },
   server: {
     proxy: {
       // Proxy to bypass CORS on fastopendata.org

--- a/package.json
+++ b/package.json
@@ -52,5 +52,12 @@
     "typescript-eslint": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"
+  },
+  "pnpm": {
+    "overrides": {
+      "@nozzleio/mosaic-tanstack-table-core": "workspace:*",
+      "@nozzleio/mosaic-tanstack-react-table": "workspace:*",
+      "@nozzleio/react-mosaic": "workspace:*"
+    }
   }
 }

--- a/packages/mosaic-tanstack-table-core/src/data-table.ts
+++ b/packages/mosaic-tanstack-table-core/src/data-table.ts
@@ -541,7 +541,7 @@ export class MosaicDataTable<
         return;
       }
 
-      const values = this.#rowSelectionManager.getCurrentValues();
+      const values = this.#rowSelectionManager.getSharedValues();
       const nextSelection: Record<string, boolean> = {};
       values.forEach((value) => {
         nextSelection[String(value)] = true;

--- a/packages/mosaic-tanstack-table-core/src/selection-manager.ts
+++ b/packages/mosaic-tanstack-table-core/src/selection-manager.ts
@@ -40,6 +40,27 @@ export class MosaicSelectionManager<
     this.columnType = options.columnType ?? 'scalar';
   }
 
+  private normalizeSelectionValues(raw: unknown): Array<TValue> | null {
+    if (Array.isArray(raw)) {
+      return raw as Array<TValue>;
+    }
+
+    if (raw === null || raw === undefined) {
+      return [];
+    }
+
+    if (
+      typeof raw === 'string' ||
+      typeof raw === 'number' ||
+      typeof raw === 'boolean' ||
+      raw instanceof Date
+    ) {
+      return [raw as TValue];
+    }
+
+    return null;
+  }
+
   /**
    * Toggles a value.
    * - If value is null, clears selection.
@@ -83,14 +104,23 @@ export class MosaicSelectionManager<
    * Reads the current selection state from the Mosaic Core.
    */
   public getCurrentValues(): Array<TValue> {
-    const raw = this.selection.valueFor(this.client);
-    if (Array.isArray(raw)) {
-      return raw as Array<TValue>;
+    return (
+      this.normalizeSelectionValues(this.selection.valueFor(this.client)) ?? []
+    );
+  }
+
+  /**
+   * Reads the selection value without source scoping.
+   * This keeps remounted clients in sync when a shared Selection is reused
+   * across different table instances, such as fullscreen/table swaps.
+   */
+  public getSharedValues(): Array<TValue> {
+    const sharedValues = this.normalizeSelectionValues(this.selection.value);
+    if (sharedValues !== null) {
+      return sharedValues;
     }
-    if (raw !== null && raw !== undefined) {
-      return [raw as TValue];
-    }
-    return [];
+
+    return this.getCurrentValues();
   }
 
   /**

--- a/packages/mosaic-tanstack-table-core/tests/data-table.test.ts
+++ b/packages/mosaic-tanstack-table-core/tests/data-table.test.ts
@@ -321,6 +321,107 @@ describe('MosaicDataTable characterization', () => {
     expect(rowSelectionPredicate!.toString()).toContain("\"id\" IN ('2', '7')");
   });
 
+  test('hydrates row selection from a shared selection for remounted table clients', async () => {
+    const rowSelection = new Selection();
+    const coordinator = new FakeCoordinator();
+    const originalClient = new MosaicDataTable<AthleteRow>({
+      table: 'athletes',
+      coordinator: coordinator as never,
+      columns: [
+        { accessorKey: 'id', header: 'ID' },
+        { accessorKey: 'name', header: 'Name' },
+      ],
+      rowSelection: {
+        selection: rowSelection,
+        column: 'id',
+      },
+    });
+
+    originalClient.connect();
+    originalClient
+      .getTableOptions(originalClient.store.state)
+      .onRowSelectionChange?.({ '7': true });
+
+    const fullscreenClient = new MosaicDataTable<AthleteRow>({
+      table: 'athletes',
+      coordinator: coordinator as never,
+      columns: [
+        { accessorKey: 'id', header: 'ID' },
+        { accessorKey: 'name', header: 'Name' },
+      ],
+      rowSelection: {
+        selection: rowSelection,
+        column: 'id',
+      },
+    });
+
+    fullscreenClient.connect();
+
+    await waitFor(() => {
+      expect(fullscreenClient.store.state.tableState.rowSelection).toEqual({
+        '7': true,
+      });
+    });
+  });
+
+  test('keeps row selection visuals in sync across clients sharing one selection', async () => {
+    const rowSelection = new Selection();
+    const coordinator = new FakeCoordinator();
+    const dashboardClient = new MosaicDataTable<AthleteRow>({
+      table: 'athletes',
+      coordinator: coordinator as never,
+      columns: [
+        { accessorKey: 'id', header: 'ID' },
+        { accessorKey: 'name', header: 'Name' },
+      ],
+      rowSelection: {
+        selection: rowSelection,
+        column: 'id',
+      },
+    });
+    const fullscreenClient = new MosaicDataTable<AthleteRow>({
+      table: 'athletes',
+      coordinator: coordinator as never,
+      columns: [
+        { accessorKey: 'id', header: 'ID' },
+        { accessorKey: 'name', header: 'Name' },
+      ],
+      rowSelection: {
+        selection: rowSelection,
+        column: 'id',
+      },
+    });
+
+    dashboardClient.connect();
+    fullscreenClient.connect();
+
+    dashboardClient
+      .getTableOptions(dashboardClient.store.state)
+      .onRowSelectionChange?.({ '2': true });
+
+    await waitFor(() => {
+      expect(dashboardClient.store.state.tableState.rowSelection).toEqual({
+        '2': true,
+      });
+      expect(fullscreenClient.store.state.tableState.rowSelection).toEqual({
+        '2': true,
+      });
+    });
+
+    fullscreenClient
+      .getTableOptions(fullscreenClient.store.state)
+      .onRowSelectionChange?.({ '9': true });
+
+    await waitFor(() => {
+      expect(dashboardClient.store.state.tableState.rowSelection).toEqual({
+        '9': true,
+      });
+      expect(fullscreenClient.store.state.tableState.rowSelection).toEqual({
+        '9': true,
+      });
+    });
+  });
+
   test('only reacts to meaningful table state changes and refreshes sidecars on filter changes', () => {
     const { client } = createFlatClient();
     const requestUpdateSpy = vi

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,11 @@ catalogs:
       specifier: ^4.1.1
       version: 4.1.1
 
+overrides:
+  '@nozzleio/mosaic-tanstack-table-core': workspace:*
+  '@nozzleio/mosaic-tanstack-react-table': workspace:*
+  '@nozzleio/react-mosaic': workspace:*
+
 importers:
 
   .:


### PR DESCRIPTION
Fix row-selection persistence when a table is remounted into a different region, such as entering or leaving fullscreen.

The core change updates row-selection hydration to use the shared Mosaic selection value so the visual selected-row state stays in sync across remounts.

This PR also adds a simple enlarge/restore flow to the trimmed Nozzle PAA example so the behavior can be exercised directly.