### PR TITLE
fix row selection sync across remounted summary tables

### DIFF
--- a/.changeset/ready-snails-send.md
+++ b/.changeset/ready-snails-send.md
@@ -1,0 +1,16 @@
+---
+'@nozzleio/mosaic-tanstack-table-core': patch
+---
+
+fix(table-core): replace stale row-selection clauses across remounted clients
+
+When a table was remounted as a new client, the previous client's
+row-selection clause could remain in the shared Mosaic Selection.
+Subsequent selection updates from the new client then intersected with
+the stale clause, producing incorrect filters and stale KPI state.
+
+Reset stale row-selection clauses before publishing the current
+client's clause so shared row selection remains single-owner across
+fullscreen or enlarged table transitions.
+
+Add regression coverage for remount, replacement, and clear flows.

--- a/examples/react/trimmed/src/components/views/nozzle-paa.tsx
+++ b/examples/react/trimmed/src/components/views/nozzle-paa.tsx
@@ -521,26 +521,6 @@ function getGroupByExpression(groupBy: string) {
   return mSql.column(groupBy);
 }
 
-function buildSummarySelectionPredicate(
-  groupBy: string,
-  values: Array<string | number>,
-): ReturnType<typeof mSql.eq> | ReturnType<typeof mSql.isIn> | null {
-  if (values.length === 0) {
-    return null;
-  }
-
-  const columnExpr = getGroupByExpression(groupBy);
-
-  if (values.length === 1) {
-    return mSql.eq(columnExpr, mSql.literal(values[0]));
-  }
-
-  return mSql.isIn(
-    columnExpr,
-    values.map((value) => mSql.literal(value)),
-  );
-}
-
 function SummaryTable({
   summaryId,
   title,
@@ -680,7 +660,7 @@ function SummaryTable({
     [groupBy, title, metricLabel, helper, sparkline, filterBy, enabled],
   );
 
-  const { tableOptions, client } = useMosaicReactTable<GroupByRow>({
+  const { tableOptions } = useMosaicReactTable<GroupByRow>({
     table: queryFactory,
     filterBy: filterBy,
     manualHighlight: true,
@@ -725,24 +705,23 @@ function SummaryTable({
 
   const table = useReactTable(tableOptions);
 
-  const updateSelectionValues = (nextValues: Array<string | number>) => {
-    selection.update({
-      source: client,
-      clients: new Set([client]),
-      value: nextValues.length > 0 ? nextValues : null,
-      predicate: buildSummarySelectionPredicate(groupBy, nextValues),
-    });
+  const updateRowSelection = (nextValues: Array<string | number>) => {
+    const nextRowSelection = Object.fromEntries(
+      nextValues.map((value) => [String(value), true]),
+    );
+
+    table.setRowSelection(nextRowSelection);
   };
 
   const clearSelection = () => {
-    updateSelectionValues([]);
+    updateRowSelection([]);
   };
 
   const removeSelectedValue = (valueToRemove: string | number) => {
     const nextValues = selectedValues.filter(
       (value) => !Object.is(value, valueToRemove),
     );
-    updateSelectionValues(nextValues);
+    updateRowSelection(nextValues);
   };
 
   return (

--- a/examples/react/trimmed/tests/nozzle-paa.test.ts
+++ b/examples/react/trimmed/tests/nozzle-paa.test.ts
@@ -1,10 +1,18 @@
 import { expect, test } from '@playwright/test';
-
 import { getInit } from './utils/init';
+import type { Page } from '@playwright/test';
 
 const init = getInit('nozzle-paa');
 
 test.describe('nozzle-paa page', () => {
+  const readUniqueQuestionsKpi = async (page: Page) => {
+    const card = page.getByText('# of Unique Questions').locator('xpath=..');
+    const valueText =
+      (await card.locator(':scope > div').nth(1).textContent()) ?? '0';
+
+    return Number(valueText.replaceAll(',', '').trim());
+  };
+
   test('has the correct header', async ({ page }) => {
     await init(page);
 
@@ -120,5 +128,49 @@ test.describe('nozzle-paa page', () => {
         name: /Remove Domain selection /,
       }),
     ).toBeVisible();
+  });
+
+  test('keeps shared question selection state correct through enlarge, update, and clear', async ({
+    page,
+  }) => {
+    await init(page);
+
+    const initialKpi = await readUniqueQuestionsKpi(page);
+    const questionCard = page.getByTestId('summary-table-question');
+
+    await questionCard.locator('table tbody tr').nth(0).click();
+    await questionCard.locator('table tbody tr').nth(1).click();
+
+    await expect.poll(() => readUniqueQuestionsKpi(page)).toBe(2);
+    await expect(page.getByText('Selected Question:')).toHaveCount(2);
+
+    await page
+      .getByRole('button', { name: 'Enlarge PAA Questions table' })
+      .click();
+
+    const expandedQuestionCard = page.getByTestId(
+      'summary-table-question-expanded',
+    );
+    await expandedQuestionCard.locator('table tbody tr').nth(2).click();
+
+    await expect.poll(() => readUniqueQuestionsKpi(page)).toBe(3);
+    await expect(page.getByText('Selected Question:')).toHaveCount(3);
+
+    await expandedQuestionCard
+      .getByRole('button', { name: 'Return PAA Questions table to grid' })
+      .click();
+
+    const restoredQuestionCard = page.getByTestId('summary-table-question');
+    await restoredQuestionCard
+      .getByRole('button', { name: 'Clear PAA Questions selections' })
+      .click();
+
+    await expect.poll(() => readUniqueQuestionsKpi(page)).toBe(initialKpi);
+    await expect(page.getByText('Selected Question:')).toHaveCount(0);
+    await expect(
+      restoredQuestionCard.getByRole('button', {
+        name: 'Clear PAA Questions selections',
+      }),
+    ).toHaveCount(0);
   });
 });

--- a/packages/mosaic-tanstack-table-core/src/selection-manager.ts
+++ b/packages/mosaic-tanstack-table-core/src/selection-manager.ts
@@ -162,6 +162,16 @@ export class MosaicSelectionManager<
       }
     }
 
+    const staleClauses = this.selection.clauses.filter(
+      (clause) => clause.source !== this.client,
+    );
+
+    if (staleClauses.length > 0) {
+      // Row selection is shared across remounted table clients, so only the
+      // current client should publish the active clause at any given time.
+      this.selection.reset(staleClauses);
+    }
+
     this.selection.update({
       source: this.client,
       // Critical: Exclude self from the filter so menus/tables don't filter themselves empty

--- a/packages/mosaic-tanstack-table-core/tests/data-table.test.ts
+++ b/packages/mosaic-tanstack-table-core/tests/data-table.test.ts
@@ -419,6 +419,105 @@ describe('MosaicDataTable characterization', () => {
       expect(fullscreenClient.store.state.tableState.rowSelection).toEqual({
         '9': true,
       });
+      expect(rowSelection.clauses).toHaveLength(1);
+      expect(rowSelection.active?.source).toBe(fullscreenClient);
+      expect(rowSelection.value).toEqual(['9']);
+    });
+  });
+
+  test('replaces stale row selection clauses when a remounted client updates the selection', async () => {
+    const rowSelection = new Selection();
+    const coordinator = new FakeCoordinator();
+    const dashboardClient = new MosaicDataTable<AthleteRow>({
+      table: 'athletes',
+      coordinator: coordinator as never,
+      columns: [
+        { accessorKey: 'id', header: 'ID' },
+        { accessorKey: 'name', header: 'Name' },
+      ],
+      rowSelection: {
+        selection: rowSelection,
+        column: 'id',
+      },
+    });
+
+    dashboardClient.connect();
+    dashboardClient
+      .getTableOptions(dashboardClient.store.state)
+      .onRowSelectionChange?.({ '2': true, '7': true });
+
+    const fullscreenClient = new MosaicDataTable<AthleteRow>({
+      table: 'athletes',
+      coordinator: coordinator as never,
+      columns: [
+        { accessorKey: 'id', header: 'ID' },
+        { accessorKey: 'name', header: 'Name' },
+      ],
+      rowSelection: {
+        selection: rowSelection,
+        column: 'id',
+      },
+    });
+
+    fullscreenClient.connect();
+    fullscreenClient
+      .getTableOptions(fullscreenClient.store.state)
+      .onRowSelectionChange?.({ '2': true, '7': true, '9': true });
+
+    await waitFor(() => {
+      expect(rowSelection.clauses).toHaveLength(1);
+      expect(rowSelection.active?.source).toBe(fullscreenClient);
+      expect(rowSelection.value).toEqual(['2', '7', '9']);
+      expect(rowSelection.active?.predicate?.toString()).toContain(
+        "\"id\" IN ('2', '7', '9')",
+      );
+    });
+  });
+
+  test('clears a shared row selection from a remounted client without leaving stale clauses behind', async () => {
+    const rowSelection = new Selection();
+    const coordinator = new FakeCoordinator();
+    const dashboardClient = new MosaicDataTable<AthleteRow>({
+      table: 'athletes',
+      coordinator: coordinator as never,
+      columns: [
+        { accessorKey: 'id', header: 'ID' },
+        { accessorKey: 'name', header: 'Name' },
+      ],
+      rowSelection: {
+        selection: rowSelection,
+        column: 'id',
+      },
+    });
+
+    dashboardClient.connect();
+    dashboardClient
+      .getTableOptions(dashboardClient.store.state)
+      .onRowSelectionChange?.({ '2': true, '7': true });
+
+    const fullscreenClient = new MosaicDataTable<AthleteRow>({
+      table: 'athletes',
+      coordinator: coordinator as never,
+      columns: [
+        { accessorKey: 'id', header: 'ID' },
+        { accessorKey: 'name', header: 'Name' },
+      ],
+      rowSelection: {
+        selection: rowSelection,
+        column: 'id',
+      },
+    });
+
+    fullscreenClient.connect();
+    fullscreenClient
+      .getTableOptions(fullscreenClient.store.state)
+      .onRowSelectionChange?.({});
+
+    await waitFor(() => {
+      expect(rowSelection.clauses).toHaveLength(0);
+      expect(rowSelection.value).toBeNull();
+      expect(dashboardClient.store.state.tableState.rowSelection).toEqual({});
+      expect(fullscreenClient.store.state.tableState.rowSelection).toEqual({});
     });
   });
 


### PR DESCRIPTION
This fixes a row-selection sync bug that showed up when a summary table
was enlarged into a separate view and then updated there.

Previously, the original table client could leave behind a stale
row-selection clause in the shared Mosaic `Selection`. When the enlarged
table updated its own selection, the shared filter state effectively
became the intersection of the stale clause and the new clause. In the
Nozzle PAA flow, that caused KPI values to stick and the Active filters
bar to show unexpected selections.