### PR TITLE
[codex] test(table-core): stabilize facet filter matcher

### DIFF
--- a/packages/mosaic-tanstack-table-core/tests/data-table.test.ts
+++ b/packages/mosaic-tanstack-table-core/tests/data-table.test.ts
@@ -1129,14 +1129,11 @@ describe('MosaicDataTable characterization', () => {
     }));
 
     coordinator.enqueueResponse(
-      (sql) =>
-        sql.includes('FROM "athletes"') && !sql.includes('GROUP BY "country"'),
+      (sql) => sql.includes('FROM "athletes"') && !sql.includes('GROUP BY'),
       createArrowTable([]),
     );
     coordinator.enqueueResponse(
-      (sql) =>
-        sql.includes('GROUP BY "country"') &&
-        sql.includes('"status" = \'active\''),
+      (sql) => sql.includes('GROUP BY') && sql.includes('"country"'),
       createArrowTable([{ country: 'NZ' }, { country: 'AU' }]),
     );
 
@@ -1153,12 +1150,12 @@ describe('MosaicDataTable characterization', () => {
     });
 
     const facetQuery = coordinator.requestLog.find(
-      ({ sql }) =>
-        sql.includes('GROUP BY "country"') &&
-        sql.includes('"status" = \'active\''),
+      ({ sql }) => sql.includes('GROUP BY') && sql.includes('"country"'),
     )?.sql;
 
     expect(facetQuery).toBeDefined();
+    expect(facetQuery).toContain('"status"');
+    expect(facetQuery).toContain("'active'");
     expect(facetQuery).not.toContain('"country" = \'NZ\'');
     expect(client.getFacetValue<Array<unknown>>('country')).toEqual([
       'NZ',


### PR DESCRIPTION
## Summary
Adjusts the table-core sidecar facet characterization test so the fake coordinator responds to the country facet query by query shape, then verifies behavior on the captured SQL.

The test now checks that the sidecar query:
- groups by the requested facet column
- keeps the non-facet `status = active` filter represented in the query
- omits the active `country = NZ` facet filter
- stores the returned facet values

## Why
The CI failures showed the mock response matchers were still too tied to one exact SQL rendering. One matcher could miss the grouped facet query, and the broader table-query matcher could then consume it and return an empty table, causing `getFacetValue('country')` to remain `[]`.

The updated matchers distinguish the main table query from sidecar facet queries by the presence of `GROUP BY`, while still asserting the behavioral SQL expectations on the captured facet query.

## Validation
- `pnpm test:format`
- `pnpm --filter @nozzleio/mosaic-tanstack-table-core test:lib -- --run tests/data-table.test.ts -t "excludes the active facet column"`
- `pnpm test:types`
- `pnpm test:lib`
- `pnpm test:lint` passed with existing warnings only
- `pnpm test:build`
