### PR TITLE
feat: subquery membership filters

### DIFF
--- a/.changeset/calm-otters-rebuild.md
+++ b/.changeset/calm-otters-rebuild.md
@@ -1,0 +1,14 @@
+---
+'@nozzleio/mosaic-tanstack-table-core': patch
+---
+
+fix: prevent runaway rebuilds of subquery filters on sibling context changes
+
+`reapplyCommittedFilterSelection` republishes a subquery filter's clause when
+sibling context changes. Publishing relays synchronously back through the
+scope context (Mosaic relays a clause update to derived selections before
+committing its own value), re-entering the same listener while
+`filter.selection.clauses` still reports the pre-update predicate. The
+convergence guard therefore never matched and republished without bound,
+overflowing the stack and unmounting the consuming table. Reentrant reapplies
+for a selection are now suppressed while its publish settles.

--- a/.changeset/early-cows-invite.md
+++ b/.changeset/early-cows-invite.md
@@ -1,0 +1,7 @@
+---
+'@nozzleio/mosaic-tanstack-react-table': patch
+'@nozzleio/mosaic-tanstack-table-core': patch
+'@nozzleio/react-mosaic': patch
+---
+
+fix: upgrade mosaic packages to `^0.27.0`

--- a/.changeset/last-query-debug-surface.md
+++ b/.changeset/last-query-debug-surface.md
@@ -1,0 +1,10 @@
+---
+'@nozzleio/mosaic-tanstack-table-core': patch
+---
+
+feat: record executed main-query SQL on the client store (`_lastQuery`)
+
+Internal/experimental debug affordance: `MosaicDataTableStore._lastQuery`
+holds the stringified SQL of the most recent main table query, set right
+before submission to the coordinator. Marked `@internal`/`@experimental` —
+not part of the supported API and may change or be removed in any release.

--- a/.changeset/proud-snails-read.md
+++ b/.changeset/proud-snails-read.md
@@ -1,0 +1,21 @@
+---
+'@nozzleio/mosaic-tanstack-react-table': patch
+'@nozzleio/mosaic-tanstack-table-core': patch
+---
+
+refactor(table-core,react-table): carve out clause construction and filter dispatch for subquery support
+
+Stage 1 of subquery-filter support; no behavior changes.
+
+- add clause-factory module (createValueClause/createClearClause) as the
+  single construction point for Selection clauses, centralizing the
+  clause meta policy ahead of meta-free subquery clauses
+- route all selection.update sites in table-core through the factory
+- export ResolvedFilter/StoredFilterValue(Mode)/FilterBuilderDataType
+  from filter-builder types; make predicate dispatch and filter-client
+  mode switches exhaustive (never guards)
+- make stored-filter-value reads mode-aware: unknown future modes (e.g.
+  SUBQUERY) hydrate as empty state instead of being coerced into
+  condition values
+- react-table: reuse createClearClause in filter-scope-hook; re-export
+  the new filter-builder types

--- a/.changeset/subquery-filter-support.md
+++ b/.changeset/subquery-filter-support.md
@@ -1,0 +1,17 @@
+---
+'@nozzleio/mosaic-tanstack-table-core': minor
+'@nozzleio/mosaic-tanstack-react-table': minor
+---
+
+feat: subquery membership filters (`column [NOT] IN (SELECT ...)`)
+
+- `buildSubqueryPredicate` / `normalizeSubqueryFilterQuery` build IN-subquery
+  predicates from mosaic-sql queries; `createSubqueryClause` publishes them as
+  Selection clauses that never carry optimizer `meta`
+- filter-builder definitions accept a `subquery` factory: the predicate is
+  rebuilt from the serializable binding state, so bindings, facets, and
+  persistence work unchanged; runtimes accept a `context` Selection so
+  factories can embed sibling-filter predicates, with automatic, convergent
+  rebuilds on context changes (`reapplyCommittedFilterSelection`)
+- `MosaicFilter` / `useMosaicTableFilter` gain a `SUBQUERY` mode with a
+  type-required `subquery` factory option

--- a/docs/core/concepts.md
+++ b/docs/core/concepts.md
@@ -166,6 +166,12 @@ The adapter supports several filter strategies out of the box:
 
 Custom strategies can be registered via `filterStrategies` option.
 
+Beyond literal-value strategies, subquery membership predicates
+(`column [NOT] IN (SELECT ...)`) are supported via `buildSubqueryPredicate`,
+`MosaicFilter` mode `SUBQUERY`, and filter-builder definitions with a
+`subquery` factory — see
+[Subquery Filters](../react/filter-builder.md#subquery-filters).
+
 ## Facets
 
 A **Facet** is metadata about a column's values, used to populate dropdowns or determine slider bounds.

--- a/docs/react/filter-builder.md
+++ b/docs/react/filter-builder.md
@@ -324,6 +324,66 @@ Native OR support inside `useMosaicFilters` (e.g. a `mode: 'union'` scope
 option) is a potential future addition — see
 `docs/react/filter-builder-design.md`.
 
+## Subquery Filters
+
+Add a `subquery` factory to any definition to build its predicate as
+`column [NOT] IN (SELECT ...)` instead of a literal-value condition. The
+factory receives the committed binding state and returns a mosaic-sql `Query`
+(or `{ query, negate }`, or `null` for "no filter"):
+
+```ts
+import { Query, count, gte } from '@uwdata/mosaic-sql';
+
+const popularQuestions = {
+  id: 'popular',
+  label: 'Popular questions',
+  column: 'question',
+  valueKind: 'number', // the UI edits the threshold parameter
+  operators: [NUMBER_CONDITIONS.GTE],
+  defaultOperator: NUMBER_CONDITIONS.GTE,
+  dataType: 'number',
+  subquery: ({ state, contextPredicate }) => {
+    if (state.value == null) return null;
+
+    const query = Query.select('question')
+      .from('data')
+      .groupby('question')
+      .having(gte(count(), Number(state.value)));
+
+    // Optional: respect sibling filters inside the subquery. Mosaic does
+    // not push other clauses into scalar subqueries automatically.
+    if (contextPredicate) query.where(contextPredicate);
+
+    return query;
+  },
+} satisfies FilterDefinition;
+```
+
+Key properties:
+
+- **`valueKind` describes the parameter UI, not the predicate.** The binding
+  state (`operator`, `value`, `valueTo`) is handed to the factory; the
+  factory interprets it. Bindings, facets, and persistence work unchanged.
+- **Persistence works out of the box.** Only the serializable binding state
+  is persisted; hydration rebuilds the predicate through the definition's
+  factory. No query serialization, no factory registry.
+- **Sibling context.** Inside `useMosaicFilters`, subquery runtimes receive
+  the scope context automatically: `contextPredicate` is the AND of the other
+  filters' predicates (the filter's own clause is excluded). Committed
+  subquery clauses are rebuilt when siblings change; rebuilds no-op once the
+  predicate converges. Avoid making two subquery filters mutually
+  context-dependent — each rebuild would embed the other's previous predicate
+  and never converge.
+- **No pre-aggregation.** Subquery clauses are published without optimizer
+  `meta`, so Mosaic uses the standard (non pre-aggregated) query path.
+- **Factories must be pure and cheap.** They run on apply, on hydration, and
+  during committed-state reads.
+
+For imperative use outside the filter-builder, `useMosaicTableFilter`
+supports `mode: 'SUBQUERY'` with a `subquery: (value) => Query | { query,
+negate } | null` factory, and the core exports `buildSubqueryPredicate` /
+`createSubqueryClause` for fully manual wiring.
+
 ## Native HTML Controls
 
 ### Text Input

--- a/examples/react/trimmed/src/components/bare-table.tsx
+++ b/examples/react/trimmed/src/components/bare-table.tsx
@@ -23,20 +23,32 @@ export function BareTable<TData extends RowData>(props: {
   columns: Array<ColumnDef<TData, any>>;
   onRowClick?: (row: Row<TData>) => void;
   onRowHover?: (row: Row<TData> | null) => void;
+  /** Fixed table layout: all columns fit the available width, cells truncate. */
+  fitColumns?: boolean;
 }) {
-  const { table, onRowClick, onRowHover } = props;
+  const { table, onRowClick, onRowHover, fitColumns = false } = props;
 
   return (
-    <div className="grid gap-4 overflow-scroll">
+    <div className={cn('grid gap-4', fitColumns ? '' : 'overflow-scroll')}>
       <div>
         <ColumnVisibilityControls table={table} />
       </div>
-      <table className="table-auto w-full">
+      <table
+        className={cn('w-full', fitColumns ? 'table-fixed' : 'table-auto')}
+      >
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id} className="py-1">
               {headerGroup.headers.map((header) => (
-                <th key={header.id} className="px-2 py-0.5">
+                <th
+                  key={header.id}
+                  className={cn('px-2 py-0.5', fitColumns && 'truncate')}
+                  style={
+                    fitColumns && header.column.columnDef.size !== undefined
+                      ? { width: header.column.columnDef.size }
+                      : undefined
+                  }
+                >
                   {header.isPlaceholder ? null : (
                     <div className="h-full grid gap-1 items-start justify-start m-0">
                       {flexRender(
@@ -72,7 +84,10 @@ export function BareTable<TData extends RowData>(props: {
                 onMouseLeave={() => onRowHover?.(null)}
               >
                 {row.getVisibleCells().map((cell) => (
-                  <td key={cell.id} className="text-nowrap px-2">
+                  <td
+                    key={cell.id}
+                    className={cn('text-nowrap px-2', fitColumns && 'truncate')}
+                  >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </td>
                 ))}

--- a/examples/react/trimmed/src/components/filter-builder/dynamic-filter-editor.tsx
+++ b/examples/react/trimmed/src/components/filter-builder/dynamic-filter-editor.tsx
@@ -267,6 +267,41 @@ export function DynamicFilterEditor({
     );
   }
 
+  if (filter.definition.valueKind === 'number') {
+    return (
+      <FilterValueShell label="Value">
+        {unary ? (
+          <ApplyUnaryButton
+            binding={binding}
+            filterLabel={filter.definition.label}
+            scopeLabel={scopeLabel}
+          />
+        ) : (
+          <div className="grid gap-2">
+            <input
+              aria-label={`${scopeLabel} ${filter.definition.label} value`}
+              className="h-9 rounded-md border border-slate-300 bg-white px-3 text-sm"
+              type="number"
+              value={toSingleInputValue(binding.value)}
+              onChange={(event) =>
+                binding.setValue(normalizeNumberValue(event.target.value))
+              }
+            />
+            <div className="flex justify-start">
+              <button
+                type="button"
+                className="inline-flex h-9 items-center justify-center rounded-md border border-slate-300 px-3 text-sm text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+                onClick={() => binding.apply()}
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+        )}
+      </FilterValueShell>
+    );
+  }
+
   if (
     filter.definition.valueKind === 'date-range' ||
     filter.definition.valueKind === 'number-range'

--- a/examples/react/trimmed/src/components/paa/paa-filters.tsx
+++ b/examples/react/trimmed/src/components/paa/paa-filters.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { Check, ChevronDown, X } from 'lucide-react';
+import * as mSql from '@uwdata/mosaic-sql';
 import {
   useMosaicTableFacetMenu,
   useMosaicTableFilter,
@@ -508,6 +509,84 @@ export function DateRangeFilter({ label, column, selection }: FilterProps) {
           onChange={(e) => setEnd(e.target.value)}
         />
       </div>
+    </div>
+  );
+}
+
+/**
+ * Subquery membership filter: keep rows whose PAA question appears on at
+ * least N distinct domains. Demonstrates `useMosaicTableFilter` in SUBQUERY
+ * mode — the predicate becomes:
+ *
+ *   related_phrase.phrase IN (
+ *     SELECT related_phrase.phrase FROM <table>
+ *     GROUP BY related_phrase.phrase
+ *     HAVING count(DISTINCT domain) >= N
+ *   )
+ */
+export function QuestionMinDomainsFilter({
+  label,
+  table,
+  selection,
+}: FilterProps) {
+  const filter = useMosaicTableFilter({
+    selection,
+    column: 'related_phrase.phrase',
+    mode: 'SUBQUERY',
+    debounceTime: 400,
+    id: 'question-min-domains',
+    subquery: (value) => {
+      const minDomains = Number(value);
+      if (!Number.isFinite(minDomains) || minDomains <= 0) {
+        return null;
+      }
+
+      const questionExpr = mSql.sql`"related_phrase"."phrase"`;
+      return mSql.Query.select({ question: questionExpr })
+        .from(table)
+        .groupby(questionExpr)
+        .having(mSql.gte(mSql.count('domain').distinct(), minDomains));
+    },
+  });
+
+  const [val, setVal] = useState('');
+
+  useEffect(() => {
+    const onSelectionChange = () => {
+      // Robust check for "Empty Selection" (global reset / chip removal)
+      const v = selection.value;
+      const isEmpty =
+        v === null || v === undefined || (Array.isArray(v) && v.length === 0);
+
+      if (isEmpty) {
+        setVal('');
+      }
+    };
+
+    selection.addEventListener('value', onSelectionChange);
+    return () => selection.removeEventListener('value', onSelectionChange);
+  }, [selection]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setVal(value);
+    filter.setValue(value === '' ? null : Number(value));
+  };
+
+  return (
+    <div className="flex flex-col gap-1 w-[150px]">
+      <label className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+        {label}
+      </label>
+      <Input
+        data-testid="question-min-domains-input"
+        type="number"
+        min={1}
+        value={val}
+        onChange={handleChange}
+        className="h-9 bg-white border-slate-200"
+        placeholder="≥ N domains"
+      />
     </div>
   );
 }

--- a/examples/react/trimmed/src/components/paa/serp-appearances-filter.tsx
+++ b/examples/react/trimmed/src/components/paa/serp-appearances-filter.tsx
@@ -1,0 +1,268 @@
+/**
+ * SERP Appearances widget filter for the PAA Questions summary table.
+ *
+ * One logical filter producing two predicates from a single (operator, value)
+ * input, gated by an explicit "apply" checkbox:
+ *
+ * 1. HAVING `count(*) >/< N` — published into the `having` Selection and
+ *    routed to the question table's own grouped query via `havingBy`.
+ * 2. Membership subquery
+ *    `related_phrase.phrase IN (SELECT related_phrase.phrase FROM nozzle_paa
+ *      WHERE <question context> GROUP BY 1 HAVING count(*) >/< N)`
+ *    — published into the `members` Selection that sibling widgets, the
+ *    detail table, the facet inputs, and the KPIs include in their contexts.
+ *
+ * The subquery embeds the question table's own filter context (top-bar
+ * inputs + detail filters + the OTHER summary selections) so the sibling
+ * subset matches exactly what the question widget displays. It is rebuilt
+ * whenever that context changes; republish is skipped when the predicate is
+ * unchanged, so the rebuild converges.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import * as mSql from '@uwdata/mosaic-sql';
+import {
+  buildSubqueryPredicate,
+  createClearClause,
+  createSubqueryClause,
+  createValueClause,
+} from '@nozzleio/mosaic-tanstack-react-table/helpers';
+import type { Selection, SelectionClause } from '@uwdata/mosaic-core';
+import type { ExprNode } from '@uwdata/mosaic-sql';
+
+const QUESTION_COLUMN = 'related_phrase.phrase';
+
+// Stable clause identities (module scope: survive remounts/enlarge swaps).
+const SERP_HAVING_SOURCE = {
+  id: 'paa-serp-having',
+  debugName: 'SERP Appears (HAVING)',
+};
+const SERP_MEMBERS_SOURCE = {
+  id: 'paa-serp-members',
+  column: 'serp_appearances',
+  debugName: 'SERP Appears',
+};
+
+export type SerpComparison = 'gt' | 'lt';
+
+export interface SerpAppearancesFilterState {
+  applied: boolean;
+  setApplied: (next: boolean) => void;
+  comparison: SerpComparison;
+  setComparison: (next: SerpComparison) => void;
+  value: number | null;
+  setValue: (next: number | null) => void;
+}
+
+function questionExpr() {
+  return mSql.sql`"related_phrase"."phrase"`;
+}
+
+function normalizeContextPredicate(
+  predicate: ReturnType<Selection['predicate']>,
+): ExprNode | null {
+  if (!predicate) {
+    return null;
+  }
+
+  if (!Array.isArray(predicate)) {
+    return predicate as ExprNode;
+  }
+
+  if (predicate.length === 0) {
+    return null;
+  }
+
+  const [first, ...rest] = predicate;
+  if (rest.length === 0) {
+    return (first ?? null) as ExprNode | null;
+  }
+
+  return mSql.and(...predicate);
+}
+
+function updateClauseIfChanged(
+  selection: Selection,
+  clause: SelectionClause,
+): void {
+  const current = selection.clauses.find(
+    (existing) => existing.source === clause.source,
+  );
+
+  if (
+    current?.predicate != null &&
+    clause.predicate != null &&
+    String(current.predicate) === String(clause.predicate)
+  ) {
+    return;
+  }
+
+  selection.update(clause);
+}
+
+export function useSerpAppearancesFilter({
+  tableName,
+  having,
+  members,
+  context,
+  enabled,
+}: {
+  tableName: string;
+  /** Selection routed to the question table's HAVING clause. */
+  having: Selection;
+  /** Selection carrying the membership subquery for sibling widgets. */
+  members: Selection;
+  /** The question table's filter context (inputs + detail + other summaries). */
+  context: Selection;
+  enabled: boolean;
+}): SerpAppearancesFilterState {
+  const [applied, setApplied] = useState(false);
+  const [comparison, setComparison] = useState<SerpComparison>('gt');
+  const [value, setValue] = useState<number | null>(null);
+
+  const isActive =
+    applied && value !== null && Number.isFinite(value) && value >= 0;
+
+  const publish = useCallback(() => {
+    if (!isActive) {
+      having.update(createClearClause(SERP_HAVING_SOURCE));
+      members.update(createClearClause(SERP_MEMBERS_SOURCE));
+      return;
+    }
+
+    const compare = comparison === 'lt' ? mSql.lt : mSql.gt;
+    const label = `${comparison === 'lt' ? '<' : '>'} ${value}`;
+
+    // 1. HAVING clause for the question table's own grouped query.
+    updateClauseIfChanged(
+      having,
+      createValueClause({
+        source: SERP_HAVING_SOURCE,
+        value: label,
+        predicate: compare(mSql.count(), mSql.literal(value)),
+      }),
+    );
+
+    // 2. Membership subquery for the sibling widgets, scoped to the same
+    //    context the question table sees.
+    const subquery = mSql.Query.select({ question: questionExpr() })
+      .from(tableName)
+      .groupby(questionExpr())
+      .having(compare(mSql.count(), mSql.literal(value)));
+
+    const contextPredicate = normalizeContextPredicate(context.predicate(null));
+    if (contextPredicate) {
+      subquery.where(contextPredicate);
+    }
+
+    updateClauseIfChanged(
+      members,
+      createSubqueryClause({
+        source: SERP_MEMBERS_SOURCE,
+        value: label,
+        predicate: buildSubqueryPredicate({
+          column: QUESTION_COLUMN,
+          query: subquery,
+        }),
+      }),
+    );
+  }, [isActive, value, comparison, having, members, context, tableName]);
+
+  // Publish on input changes.
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    publish();
+  }, [enabled, publish]);
+
+  // Rebuild the membership subquery when the question context changes.
+  useEffect(() => {
+    if (!enabled || !isActive) {
+      return;
+    }
+
+    const listener = () => {
+      publish();
+    };
+
+    context.addEventListener('value', listener);
+    return () => {
+      context.removeEventListener('value', listener);
+    };
+  }, [context, enabled, isActive, publish]);
+
+  // External clears (global reset, filter-chip removal) un-apply the filter
+  // so the checkbox state stays in sync and the HAVING clause is dropped too.
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    const listener = () => {
+      const stillPublished = members.clauses.some(
+        (clause) => clause.source === SERP_MEMBERS_SOURCE,
+      );
+
+      if (!stillPublished) {
+        setApplied(false);
+      }
+    };
+
+    members.addEventListener('value', listener);
+    return () => {
+      members.removeEventListener('value', listener);
+    };
+  }, [isActive, members]);
+
+  return { applied, setApplied, comparison, setComparison, value, setValue };
+}
+
+export function SerpAppearancesControls({
+  state,
+}: {
+  state: SerpAppearancesFilterState;
+}) {
+  return (
+    <div
+      data-testid="serp-appearances-filter"
+      className="flex items-center gap-2 text-xs text-slate-600"
+    >
+      <label className="flex items-center gap-1 font-semibold uppercase tracking-wide text-slate-500">
+        <input
+          data-testid="serp-appearances-apply"
+          type="checkbox"
+          className="size-3.5 cursor-pointer"
+          checked={state.applied}
+          onChange={(event) => state.setApplied(event.target.checked)}
+        />
+        SERP Appears
+      </label>
+      <select
+        data-testid="serp-appearances-op"
+        aria-label="SERP appearances comparison"
+        className="h-7 rounded border border-slate-200 bg-white px-1 text-xs"
+        value={state.comparison}
+        onChange={(event) =>
+          state.setComparison(event.target.value as SerpComparison)
+        }
+      >
+        <option value="gt">&gt;</option>
+        <option value="lt">&lt;</option>
+      </select>
+      <input
+        data-testid="serp-appearances-value"
+        aria-label="SERP appearances threshold"
+        type="number"
+        min={0}
+        placeholder="N"
+        className="h-7 w-16 rounded border border-slate-200 bg-white px-2 text-xs"
+        value={state.value ?? ''}
+        onChange={(event) => {
+          const raw = event.target.value;
+          state.setValue(raw === '' ? null : Number(raw));
+        }}
+      />
+    </div>
+  );
+}

--- a/examples/react/trimmed/src/components/render-table.tsx
+++ b/examples/react/trimmed/src/components/render-table.tsx
@@ -18,6 +18,12 @@ export function RenderTable<TData extends RowData>(props: {
   columns: Array<ColumnDef<TData, any>>;
   onRowClick?: (row: Row<TData>) => void;
   onRowHover?: (row: Row<TData> | null) => void;
+  /**
+   * Fit all columns inside the available width (fixed table layout with
+   * truncated cells) instead of allowing horizontal overflow. Columns with
+   * an explicit `size` keep it; the rest share the remaining space.
+   */
+  fitColumns?: boolean;
 }) {
   const [view] = useURLSearchParam('table-view', 'shadcn-1');
 
@@ -31,6 +37,7 @@ export function RenderTable<TData extends RowData>(props: {
             columns={props.columns}
             onRowClick={props.onRowClick}
             onRowHover={props.onRowHover}
+            fitColumns={props.fitColumns}
           />
         ) : null,
       )}

--- a/examples/react/trimmed/src/components/shadcn-table.tsx
+++ b/examples/react/trimmed/src/components/shadcn-table.tsx
@@ -64,8 +64,10 @@ export function ShadcnTable<TData extends RowData>(props: {
   columns: Array<ColumnDef<TData, any>>;
   onRowClick?: (row: Row<TData>) => void;
   onRowHover?: (row: Row<TData> | null) => void;
+  /** Fixed table layout: all columns fit the available width, cells truncate. */
+  fitColumns?: boolean;
 }) {
-  const { table, columns, onRowClick, onRowHover } = props;
+  const { table, columns, onRowClick, onRowHover, fitColumns = false } = props;
 
   return (
     <div className="grid gap-2">
@@ -78,13 +80,25 @@ export function ShadcnTable<TData extends RowData>(props: {
         </div>
       </div>
       <div className="overflow-hidden rounded-md border">
-        <Table>
+        <Table className={cn(fitColumns && 'table-fixed')}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {
+                  // In fitColumns mode, only explicitly sized columns get a
+                  // width; the remaining columns share the leftover space.
+                  const explicitSize = header.column.columnDef.size;
+
                   return (
-                    <TableHead key={header.id}>
+                    <TableHead
+                      key={header.id}
+                      className={cn(fitColumns && 'truncate')}
+                      style={
+                        fitColumns && explicitSize !== undefined
+                          ? { width: explicitSize }
+                          : undefined
+                      }
+                    >
                       <div className="grid gap-1 items-start h-full">
                         {header.isPlaceholder
                           ? null
@@ -125,7 +139,10 @@ export function ShadcnTable<TData extends RowData>(props: {
                     )}
                   >
                     {row.getVisibleCells().map((cell) => (
-                      <TableCell key={cell.id}>
+                      <TableCell
+                        key={cell.id}
+                        className={cn(fitColumns && 'truncate')}
+                      >
                         {flexRender(
                           cell.column.columnDef.cell,
                           cell.getContext(),
@@ -159,14 +176,14 @@ function DataTablePagination<TData>({
   table: TanStackTable<TData>;
 }) {
   return (
-    <div className="flex items-center justify-between px-2">
+    <div className="flex flex-wrap items-center justify-between gap-2 px-2">
       <div className="text-muted-foreground flex-1 text-sm">
         {/* {table.getFilteredSelectedRowModel().rows.length} of{' '} */}
         {/* {table.getFilteredRowModel().rows.length} row(s) selected. */}
       </div>
-      <div className="flex items-center space-x-6 lg:space-x-8">
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2 lg:gap-x-8">
         <div className="flex items-center space-x-2">
-          <p className="text-sm">Rows per page</p>
+          <p className="text-sm text-nowrap">Rows per page</p>
           <Select
             value={`${table.getState().pagination.pageSize}`}
             onValueChange={(value) => {
@@ -198,7 +215,7 @@ function DataTablePagination<TData>({
 
         <div className="flex items-center space-x-2">
           <p className="text-sm text-nowrap">Go to page</p>
-          <div>
+          <div className="w-20">
             <Input
               type="number"
               min="1"

--- a/examples/react/trimmed/src/components/views/filter-builder.tsx
+++ b/examples/react/trimmed/src/components/views/filter-builder.tsx
@@ -7,11 +7,13 @@ import { Selection } from '@uwdata/mosaic-core';
 import {
   DATE_RANGE_CONDITIONS,
   MULTISELECT_SCALAR_CONDITIONS,
+  NUMBER_CONDITIONS,
   NUMBER_RANGE_CONDITIONS,
   SELECT_CONDITIONS,
   TEXT_CONDITIONS,
   useMosaicFilters,
   useMosaicReactTable,
+  useMosaicTableFilter,
 } from '@nozzleio/mosaic-tanstack-react-table';
 import {
   coerceDate,
@@ -22,6 +24,8 @@ import {
 import {
   useCascadingContexts,
   useComposedSelection,
+  useMosaicSelection,
+  useRegisterSelections,
 } from '@nozzleio/react-mosaic';
 
 import type { ColumnDef } from '@tanstack/react-table';
@@ -186,6 +190,47 @@ const pageDefinitions: Array<FilterDefinition> = [
     defaultOperator: NUMBER_RANGE_CONDITIONS.BETWEEN,
     dataType: 'number',
   },
+  // Subquery membership filter: the binding edits a plain number (the gold
+  // threshold), and the factory turns it into
+  //   nationality IN (SELECT nationality FROM athletes
+  //                   GROUP BY nationality HAVING SUM(gold) >=/<= N)
+  // `contextPredicate` carries the OTHER active page filters, so the medal
+  // tally inside the subquery respects e.g. an active sport filter, and the
+  // clause is rebuilt automatically when those sibling filters change.
+  // See docs/react/filter-builder.md#subquery-filters.
+  {
+    id: 'nationality_medal_strength',
+    label: 'Country Golds',
+    column: 'nationality',
+    valueKind: 'number',
+    operators: [NUMBER_CONDITIONS.GTE, NUMBER_CONDITIONS.LTE],
+    defaultOperator: NUMBER_CONDITIONS.GTE,
+    dataType: 'number',
+    description:
+      'Subquery filter: athletes from countries whose total golds pass the threshold',
+    subquery: ({ state, contextPredicate }) => {
+      const threshold = Number(state.value);
+      if (!Number.isFinite(threshold)) {
+        return null;
+      }
+
+      const compare =
+        state.operator === NUMBER_CONDITIONS.LTE ? mSql.lte : mSql.gte;
+      const query = mSql.Query.select('nationality')
+        .from(tableName)
+        .where(mSql.isNotNull(mSql.column('nationality')))
+        .groupby('nationality')
+        .having(
+          compare(mSql.sql`COALESCE(SUM(gold), 0)`, mSql.literal(threshold)),
+        );
+
+      if (contextPredicate) {
+        query.where(contextPredicate);
+      }
+
+      return query;
+    },
+  },
   // Two definitions targeting the same SQL column (`date_of_birth`).
   // Each has a distinct `id`, so `useMosaicFilters` creates a separate
   // Selection for each. When both are active they AND together in the
@@ -329,6 +374,16 @@ export function FilterBuilderView() {
     page.context,
   ]);
   const widgetContext = useComposedSelection([page.context, widget.context]);
+
+  // Imperative subquery filter (no filter-builder involvement): a standalone
+  // `useMosaicTableFilter` SUBQUERY input scoped to the roster table only.
+  const sportSubquery = useMosaicSelection('intersect');
+  const sportSubquerySelections = useMemo(
+    () => [sportSubquery],
+    [sportSubquery],
+  );
+  useRegisterSelections(sportSubquerySelections);
+  const rosterContext = useComposedSelection([page.context, sportSubquery]);
   const pageAvailableDefinitions = useMemo(
     () =>
       getAvailableFiltersForScope(
@@ -518,10 +573,11 @@ export function FilterBuilderView() {
         <AthleteTableCard
           cardId="page-roster"
           title="Roster Table"
-          description="This table only consumes page filters."
-          filterBy={page.context}
+          description="This table consumes page filters plus the imperative sport subquery filter below."
+          filterBy={rosterContext}
           columns={rosterColumns}
           debugName="FilterBuilderRosterTable"
+          controls={<SportSubqueryControl selection={sportSubquery} />}
         />
       </div>
 
@@ -766,6 +822,7 @@ function AthleteTableCard({
   filterBy,
   columns,
   debugName,
+  controls,
 }: {
   cardId: string;
   title: string;
@@ -773,6 +830,7 @@ function AthleteTableCard({
   filterBy: MosaicSelection;
   columns: Array<ColumnDef<AthleteRowData, any>>;
   debugName: string;
+  controls?: React.ReactNode;
 }) {
   const havingBy = useMemo(() => Selection.intersect(), []);
   const { client, tableOptions } = useMosaicReactTable<AthleteRowData>({
@@ -845,8 +903,85 @@ function AthleteTableCard({
           {summaryText}
         </p>
       </div>
+      {controls}
       <RenderTable table={table} columns={columns} />
     </div>
+  );
+}
+
+/**
+ * Imperative subquery filter over the roster table:
+ * `sport IN (SELECT sport FROM athletes GROUP BY sport
+ *            HAVING COUNT(CASE WHEN gold > 0 THEN 1 END) >= N)`.
+ *
+ * Uses `useMosaicTableFilter` in SUBQUERY mode — no filter-builder
+ * definitions involved; the predicate is published into a dedicated
+ * Selection composed into the roster's `filterBy`.
+ */
+function SportSubqueryControl({ selection }: { selection: MosaicSelection }) {
+  const filter = useMosaicTableFilter({
+    selection,
+    column: 'sport',
+    mode: 'SUBQUERY',
+    debounceTime: 300,
+    id: 'roster-sport-subquery',
+    subquery: (value) => {
+      const minGoldMedalists = Number(value);
+      if (!Number.isFinite(minGoldMedalists) || minGoldMedalists <= 0) {
+        return null;
+      }
+
+      return mSql.Query.select('sport')
+        .from(tableName)
+        .where(mSql.isNotNull(mSql.column('sport')))
+        .groupby('sport')
+        .having(
+          mSql.gte(
+            mSql.sql`COUNT(CASE WHEN gold > 0 THEN 1 END)`,
+            mSql.literal(minGoldMedalists),
+          ),
+        );
+    },
+  });
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    const onSelectionChange = () => {
+      // Sync the input when the selection is cleared externally
+      // (e.g. global reset).
+      if (selection.value === null || selection.value === undefined) {
+        setValue('');
+      }
+    };
+
+    selection.addEventListener('value', onSelectionChange);
+    return () => selection.removeEventListener('value', onSelectionChange);
+  }, [selection]);
+
+  return (
+    <label className="flex flex-wrap items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
+      <span className="font-medium">
+        Only sports with at least
+        <input
+          data-testid="roster-sport-subquery-input"
+          aria-label="Minimum gold medalists per sport"
+          type="number"
+          min={1}
+          placeholder="N"
+          className="mx-2 h-8 w-20 rounded-md border border-slate-300 bg-white px-2 text-sm"
+          value={value}
+          onChange={(event) => {
+            const nextValue = event.target.value;
+            setValue(nextValue);
+            filter.setValue(nextValue === '' ? null : Number(nextValue));
+          }}
+        />
+        gold medalists
+      </span>
+      <span className="text-xs text-slate-500">
+        (imperative `useMosaicTableFilter` SUBQUERY mode)
+      </span>
+    </label>
   );
 }
 

--- a/examples/react/trimmed/src/components/views/nozzle-paa.tsx
+++ b/examples/react/trimmed/src/components/views/nozzle-paa.tsx
@@ -31,10 +31,16 @@ import { useMosaicValue } from '@/hooks/useMosaicValue';
 import {
   ArraySelectFilter,
   DateRangeFilter,
+  QuestionMinDomainsFilter,
   SearchableSelectFilter,
   TextFilter,
 } from '@/components/paa/paa-filters';
+import {
+  SerpAppearancesControls,
+  useSerpAppearancesFilter,
+} from '@/components/paa/serp-appearances-filter';
 import { SparklineCell } from '@/components/paa/sparkline';
+import { WidgetSqlDetails } from '@/components/widget-sql-details';
 import { ActiveFilterBar } from '@/components/active-filter-bar';
 import { Button } from '@/components/ui/button';
 
@@ -99,6 +105,16 @@ export function NozzlePaaView() {
   const topology = usePaaTopology();
   const filterRegistry = useFilterRegistry();
 
+  // SERP Appearances widget filter (PAA Questions table). State lives here
+  // so it survives the Enlarge/Return remounts of the summary table.
+  const serpFilter = useSerpAppearancesFilter({
+    tableName: TABLE_NAME,
+    having: topology.questionSerp.having,
+    members: topology.questionSerp.members,
+    context: topology.questionContext,
+    enabled: isReady,
+  });
+
   // Stable Aggregation Function for Phrase Table
   const maxAgg = useMemo(() => (e: any) => mSql.max(e), []);
 
@@ -132,6 +148,9 @@ export function NozzlePaaView() {
           aggFn: mSql.count,
           filterBy: topology.questionContext,
           selection: topology.selections.question,
+          // SERP Appearances filter routes to this table's HAVING clause;
+          // siblings receive the membership subquery via their contexts.
+          havingBy: topology.questionSerp.having,
         },
         {
           id: 'domain',
@@ -202,6 +221,9 @@ export function NozzlePaaView() {
   useRegisterFilterSource(topology.inputs.question, 'global', {
     labelMap: { 'related_phrase.phrase': 'Question' },
   });
+  useRegisterFilterSource(topology.inputs.questionDomains, 'global', {
+    labelMap: { 'related_phrase.phrase': 'Min Domains' },
+  });
 
   // Register Summary Table Output Selections
   useRegisterFilterSource(topology.selections.phrase, 'summary', {
@@ -219,6 +241,12 @@ export function NozzlePaaView() {
   useRegisterFilterSource(topology.selections.url, 'summary', {
     labelMap: { url: 'Selected URL' },
     explodeArrayValues: true,
+  });
+
+  // Register the SERP Appearances membership filter (the chip's X clears the
+  // members clause; the widget hook then un-applies and drops HAVING too).
+  useRegisterFilterSource(topology.questionSerp.members, 'summary', {
+    labelMap: { serp_appearances: 'SERP Appears' },
   });
 
   // Register Detail Table Column Filters
@@ -354,6 +382,12 @@ export function NozzlePaaView() {
             column="related_phrase.phrase"
             selection={topology.inputs.question}
           />
+          <QuestionMinDomainsFilter
+            label="Question Domains"
+            table={TABLE_NAME}
+            column="related_phrase.phrase"
+            selection={topology.inputs.questionDomains}
+          />
         </div>
       </div>
 
@@ -377,6 +411,11 @@ export function NozzlePaaView() {
               {...summaryTable}
               enabled={isReady}
               heightClassName="h-[700px]"
+              headerControls={
+                summaryTable.id === 'question' ? (
+                  <SerpAppearancesControls state={serpFilter} />
+                ) : undefined
+              }
               promotionButton={
                 <Button
                   variant="ghost"
@@ -403,6 +442,11 @@ export function NozzlePaaView() {
             enabled={isReady}
             heightClassName="h-[820px]"
             promoted
+            headerControls={
+              expandedTable.id === 'question' ? (
+                <SerpAppearancesControls state={serpFilter} />
+              ) : undefined
+            }
             promotionButton={
               <Button
                 variant="outline"
@@ -523,6 +567,8 @@ type SummaryTableConfig = {
   filterBy: Selection;
   selection: Selection;
   sparkline?: SparklineCellConfig;
+  /** Optional HAVING-targeted Selection for aggregate predicates. */
+  havingBy?: Selection;
 };
 
 function getGroupByExpression(groupBy: string) {
@@ -544,9 +590,11 @@ function SummaryTable({
   where,
   filterBy,
   selection,
+  havingBy,
   enabled,
   sparkline,
   heightClassName,
+  headerControls,
   promotionButton,
   promoted = false,
 }: {
@@ -559,9 +607,11 @@ function SummaryTable({
   where?: FilterExpr;
   filterBy: Selection;
   selection: Selection;
+  havingBy?: Selection;
   enabled: boolean;
   sparkline?: SparklineCellConfig;
   heightClassName: string;
+  headerControls?: React.ReactNode;
   promotionButton?: React.ReactNode;
   promoted?: boolean;
 }) {
@@ -643,10 +693,18 @@ function SummaryTable({
         id: 'key',
         header: title,
         enableColumnFilter: false,
+        // No explicit size: the key column absorbs the space left over by
+        // the fixed-width columns (fitColumns mode truncates long values).
+        cell: (info) => {
+          const value = info.getValue();
+          const text = value === null ? '' : String(value);
+          return <span title={text}>{text}</span>;
+        },
       }),
       helper.accessor('metric', {
         id: 'metric',
         header: metricLabel,
+        size: 105,
         cell: (info) => info.getValue()?.toLocaleString(),
         enableColumnFilter: false,
       }),
@@ -684,9 +742,10 @@ function SummaryTable({
     [groupBy, title, metricLabel, helper, sparkline, filterBy, enabled],
   );
 
-  const { tableOptions } = useMosaicReactTable<GroupByRow>({
+  const { tableOptions, client } = useMosaicReactTable<GroupByRow>({
     table: queryFactory,
     filterBy: filterBy,
+    havingBy,
     manualHighlight: true,
     totalRowsMode: 'split',
     rowSelection: {
@@ -766,6 +825,11 @@ function SummaryTable({
           {promotionButton}
         </div>
       </div>
+      {headerControls ? (
+        <div className="px-4 py-2 border-b bg-amber-50/60 flex items-center justify-between gap-3">
+          {headerControls}
+        </div>
+      ) : null}
       {selectedValues.length > 0 ? (
         <div className="px-4 py-3 border-b bg-blue-50/60 flex flex-wrap items-center gap-2">
           <div className="text-[11px] font-semibold uppercase tracking-wide text-blue-900">
@@ -802,13 +866,15 @@ function SummaryTable({
           </Button>
         </div>
       ) : null}
-      <div className="flex-1 overflow-auto p-2">
+      <div className="flex-1 overflow-y-auto overflow-x-hidden p-2">
         <RenderTable
           table={table}
           columns={tableOptions.columns}
           onRowClick={(row) => row.toggleSelected()}
+          fitColumns
         />
       </div>
+      <WidgetSqlDetails client={client} />
     </div>
   );
 }
@@ -881,7 +947,7 @@ function DetailTable({
     [helper],
   );
 
-  const { tableOptions } = useMosaicReactTable<PaaRowData>({
+  const { tableOptions, client } = useMosaicReactTable<PaaRowData>({
     table: TABLE_NAME,
     filterBy: topology.detailContext,
     tableFilterSelection: topology.detail,
@@ -898,5 +964,12 @@ function DetailTable({
   });
 
   const table = useReactTable(tableOptions);
-  return <RenderTable table={table} columns={columns} />;
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 overflow-auto">
+        <RenderTable table={table} columns={columns} />
+      </div>
+      <WidgetSqlDetails client={client} />
+    </div>
+  );
 }

--- a/examples/react/trimmed/src/components/widget-sql-details.tsx
+++ b/examples/react/trimmed/src/components/widget-sql-details.tsx
@@ -1,0 +1,51 @@
+/**
+ * Collapsible footer that surfaces the SQL last executed by a Mosaic table
+ * client, read from the client store's `_lastQuery` debug field.
+ *
+ * NOTE: `_lastQuery` is an `@internal` / `@experimental` debug affordance of
+ * `@nozzleio/mosaic-tanstack-table-core` — useful for demos and debugging,
+ * but not a supported API to build product features on.
+ */
+import * as React from 'react';
+
+interface SqlDebugClient {
+  store: {
+    subscribe: (onChange: () => void) => { unsubscribe: () => void };
+    state: { _lastQuery: string | undefined };
+  };
+}
+
+export function WidgetSqlDetails({ client }: { client: SqlDebugClient }) {
+  const subscribe = React.useCallback(
+    (onChange: () => void) => {
+      const subscription = client.store.subscribe(onChange);
+      return () => {
+        subscription.unsubscribe();
+      };
+    },
+    [client.store],
+  );
+  const sql = React.useSyncExternalStore(
+    subscribe,
+    () => client.store.state._lastQuery,
+    () => client.store.state._lastQuery,
+  );
+
+  if (!sql) {
+    return null;
+  }
+
+  return (
+    <details
+      data-testid="widget-sql"
+      className="border-t bg-slate-50/60 px-3 py-1.5 text-[11px] text-slate-500"
+    >
+      <summary className="cursor-pointer select-none font-semibold uppercase tracking-wide">
+        SQL
+      </summary>
+      <pre className="mt-1.5 max-h-44 overflow-y-auto rounded border border-slate-200 bg-white p-2 whitespace-pre-wrap break-all text-[10px] leading-4 text-slate-600">
+        {sql}
+      </pre>
+    </details>
+  );
+}

--- a/examples/react/trimmed/src/hooks/usePaaTopology.ts
+++ b/examples/react/trimmed/src/hooks/usePaaTopology.ts
@@ -9,6 +9,7 @@ import { useMemo } from 'react';
 import { Selection } from '@uwdata/mosaic-core';
 import {
   useCascadingContexts,
+  useComposedSelection,
   useMosaicSelection,
   useMosaicSelections,
   useRegisterSelections,
@@ -26,6 +27,8 @@ const INPUT_KEYS = [
   'date',
   'device',
   'question',
+  // Subquery membership input: question seen on >= N distinct domains.
+  'questionDomains',
 ] as const;
 
 const SUMMARY_KEYS = ['domain', 'phrase', 'question', 'url'] as const;
@@ -40,11 +43,23 @@ export function usePaaTopology() {
   // 3. Instantiate Explicit Outputs for Summary Tables (Batch)
   const summaries = useMosaicSelections(SUMMARY_KEYS);
 
+  // 3b. SERP Appearances widget filter (PAA Questions table).
+  //     One logical filter, two predicates:
+  //     - `serpHaving` carries `HAVING count(*) > N` for the question table's
+  //       own grouped query (via `havingBy`).
+  //     - `serpMembers` carries the membership subquery
+  //       `related_phrase.phrase IN (SELECT ... GROUP BY ... HAVING ...)`
+  //       that cross-filters the sibling widgets to the matching subset.
+  const serpHaving = useMosaicSelection('intersect');
+  const serpMembers = useMosaicSelection('intersect');
+
   // Register all selections with the global reset context
   useRegisterSelections([
     ...Object.values(inputs),
     detail,
     ...Object.values(summaries),
+    serpHaving,
+    serpMembers,
   ]);
 
   // 4. Compute Derived Topology
@@ -64,13 +79,15 @@ export function usePaaTopology() {
 
     // C. External Context
     // What the Input Dropdowns should see from the "Outside World"
+    // (includes the SERP membership subquery so facet options match the
+    // question-widget subset)
     const externalContext = Selection.intersect({
-      include: [detail, globalCross],
+      include: [detail, globalCross, serpMembers],
     });
 
     // D. Global Context (KPIs)
     const globalContext = Selection.intersect({
-      include: [globalInput, detail, globalCross],
+      include: [globalInput, detail, globalCross, serpMembers],
     });
 
     return {
@@ -79,7 +96,7 @@ export function usePaaTopology() {
       externalContext,
       globalContext,
     };
-  }, [inputs, summaries, detail]);
+  }, [inputs, summaries, detail, serpMembers]);
 
   // 5. Wire Cascading Contexts
   //    Each input gets a context containing: [All Other Inputs] + [External Context]
@@ -97,6 +114,20 @@ export function usePaaTopology() {
     [topology.globalInput, detail],
   );
   const summaryContexts = useCascadingContexts(summaries, summaryExternals);
+
+  // 6b. Layer the SERP membership subquery onto the sibling summary tables.
+  //     The question table is deliberately excluded: it applies the same
+  //     restriction as `HAVING count(*) > N` on its own grouped query
+  //     (`serpHaving`), so the membership subquery would be redundant there.
+  const phraseContext = useComposedSelection([
+    summaryContexts.phrase,
+    serpMembers,
+  ]);
+  const domainContext = useComposedSelection([
+    summaryContexts.domain,
+    serpMembers,
+  ]);
+  const urlContext = useComposedSelection([summaryContexts.url, serpMembers]);
 
   // 7. Define Column Metadata Helpers
   const getColumnMeta = (
@@ -124,9 +155,9 @@ export function usePaaTopology() {
     detailContext: useMemo(
       () =>
         Selection.intersect({
-          include: [topology.globalInput, topology.globalCross],
+          include: [topology.globalInput, topology.globalCross, serpMembers],
         }),
-      [topology.globalInput, topology.globalCross],
+      [topology.globalInput, topology.globalCross, serpMembers],
     ),
     // Map Summary Selections/Contexts to semantic names expected by the view
     selections: {
@@ -135,10 +166,16 @@ export function usePaaTopology() {
       question: summaries.question,
       url: summaries.url,
     },
-    domainContext: summaryContexts.domain,
-    phraseContext: summaryContexts.phrase,
+    domainContext,
+    phraseContext,
     questionContext: summaryContexts.question,
-    urlContext: summaryContexts.url,
+    urlContext,
+
+    // SERP Appearances widget filter selections (PAA Questions table)
+    questionSerp: {
+      having: serpHaving,
+      members: serpMembers,
+    },
 
     globalInput: topology.globalInput,
     globalContext: topology.globalContext,

--- a/examples/react/trimmed/tests/subquery-filters.test.ts
+++ b/examples/react/trimmed/tests/subquery-filters.test.ts
@@ -1,0 +1,261 @@
+import { expect, test } from '@playwright/test';
+
+import { getInit } from './utils/init';
+import type { Locator, Page } from '@playwright/test';
+
+const initFilterBuilder = getInit('filter-builder');
+const initNozzlePaa = getInit('nozzle-paa');
+
+async function readSummary(summary: Locator) {
+  await expect(summary).toContainText('Visible rows:');
+  return (await summary.textContent()) ?? '';
+}
+
+async function addFilter(scope: Locator, filterLabel: string) {
+  await scope.getByRole('button', { name: 'Add Filter' }).click();
+  await scope
+    .getByRole('button', { name: new RegExp(`^${filterLabel}`) })
+    .click();
+}
+
+async function expectSummaryToChange(summary: Locator, previousText: string) {
+  await expect(summary).not.toHaveText(previousText, {
+    timeout: 15000,
+  });
+}
+
+test.describe('filter-builder subquery filters', () => {
+  test('declarative subquery definition filters the roster through IN (SELECT ...)', async ({
+    page,
+  }) => {
+    await initFilterBuilder(page);
+
+    const pageScope = page.getByTestId('page-filter-scope');
+    const pageSummary = page.getByTestId('page-roster-summary');
+    const widgetSummary = page.getByTestId('widget-medals-summary');
+    const initialPageSummary = await readSummary(pageSummary);
+    const initialWidgetSummary = await readSummary(widgetSummary);
+
+    await addFilter(pageScope, 'Country Golds');
+
+    const subqueryRow = page.getByTestId(
+      'page-active-filter-nationality_medal_strength',
+    );
+    await expect(subqueryRow).toBeVisible();
+
+    // gte is the default operator; just set the threshold and apply.
+    await subqueryRow.getByLabel('page Country Golds value').fill('20');
+    await subqueryRow.getByRole('button', { name: 'Apply' }).click();
+
+    // The page scope flows into both the roster and the medal widget.
+    await expectSummaryToChange(pageSummary, initialPageSummary);
+    await expectSummaryToChange(widgetSummary, initialWidgetSummary);
+
+    // Flip the operator: countries with AT MOST 20 golds — different subset.
+    const filteredSummary = await readSummary(pageSummary);
+    await subqueryRow
+      .getByLabel('page Country Golds operator')
+      .selectOption('lte');
+    await subqueryRow.getByRole('button', { name: 'Apply' }).click();
+    await expectSummaryToChange(pageSummary, filteredSummary);
+
+    // Removing the filter restores the unfiltered roster.
+    await subqueryRow
+      .getByRole('button', { name: 'Remove Country Golds filter from page' })
+      .click();
+    await expect(pageSummary).toHaveText(initialPageSummary, {
+      timeout: 15000,
+    });
+  });
+
+  test('subquery definition reacts to sibling page filters (context rebuild)', async ({
+    page,
+  }) => {
+    await initFilterBuilder(page);
+
+    const pageScope = page.getByTestId('page-filter-scope');
+    const pageSummary = page.getByTestId('page-roster-summary');
+
+    await addFilter(pageScope, 'Country Golds');
+    const subqueryRow = page.getByTestId(
+      'page-active-filter-nationality_medal_strength',
+    );
+    await subqueryRow.getByLabel('page Country Golds value').fill('5');
+    await subqueryRow.getByRole('button', { name: 'Apply' }).click();
+
+    const goldsOnlySummary = await readSummary(pageSummary);
+
+    // Constrain the sibling sport filter. The subquery factory embeds the
+    // sibling context, so "5 golds" now means "5 golds in basketball" — the
+    // qualifying-country set shrinks and the roster changes beyond the plain
+    // AND of both filters.
+    const sportRow = page.getByTestId('page-active-filter-sport');
+    await sportRow.getByLabel('page Sport value').selectOption('basketball');
+
+    await expectSummaryToChange(pageSummary, goldsOnlySummary);
+  });
+
+  test('imperative SUBQUERY-mode filter scopes only the roster table', async ({
+    page,
+  }) => {
+    await initFilterBuilder(page);
+
+    const pageSummary = page.getByTestId('page-roster-summary');
+    const widgetSummary = page.getByTestId('widget-medals-summary');
+    const initialPageSummary = await readSummary(pageSummary);
+    const initialWidgetSummary = await readSummary(widgetSummary);
+
+    const input = page.getByTestId('roster-sport-subquery-input');
+    await input.fill('30');
+
+    // Roster narrows to sports with >= 30 gold medalists...
+    await expectSummaryToChange(pageSummary, initialPageSummary);
+    // ...while the widget table (page + widget scopes only) is unaffected.
+    await expect(widgetSummary).toHaveText(initialWidgetSummary);
+
+    // Clearing the input restores the roster.
+    await input.fill('');
+    await expect(pageSummary).toHaveText(initialPageSummary, {
+      timeout: 15000,
+    });
+  });
+});
+
+test.describe('nozzle-paa subquery filters', () => {
+  const readUniqueQuestionsKpi = async (page: Page) => {
+    const card = page.getByText('# of Unique Questions').locator('xpath=..');
+    const valueText =
+      (await card.locator(':scope > div').nth(1).textContent()) ?? '0';
+
+    return Number(valueText.replaceAll(',', '').trim());
+  };
+
+  const readFirstQuestionMetric = async (page: Page) => {
+    const questionCard = page.getByTestId('summary-table-question');
+    const metricText =
+      (await questionCard
+        .locator('tbody tr')
+        .first()
+        .locator('td')
+        .nth(2)
+        .textContent()) ?? '';
+
+    return Number(metricText.replaceAll(',', '').trim());
+  };
+
+  test('SERP Appearances widget filter applies HAVING and cross-filters siblings', async ({
+    page,
+  }) => {
+    await initNozzlePaa(page);
+
+    const initialKpi = await expect
+      .poll(() => readUniqueQuestionsKpi(page))
+      .toBeGreaterThan(0)
+      .then(() => readUniqueQuestionsKpi(page));
+
+    // The question table is sorted by SERP Appears descending, so the
+    // unfiltered first row has the maximum count.
+    const initialTopMetric = await readFirstQuestionMetric(page);
+    expect(initialTopMetric).toBeGreaterThan(1);
+
+    // Apply: SERP Appears < 5 (LESS THAN exercises the strict comparison and
+    // is observable on the descending-sorted first row).
+    await page.getByTestId('serp-appearances-op').selectOption('lt');
+    await page.getByTestId('serp-appearances-value').fill('5');
+    await page.getByTestId('serp-appearances-apply').check();
+
+    // 1. Self: the question table's HAVING keeps only counts < 5.
+    await expect
+      .poll(() => readFirstQuestionMetric(page), { timeout: 15000 })
+      .toBeLessThan(5);
+
+    // 2. Siblings: the membership subquery shrinks the global KPI subset.
+    await expect
+      .poll(() => readUniqueQuestionsKpi(page), { timeout: 15000 })
+      .not.toBe(initialKpi);
+
+    // 3. The filter is visible as a removable chip.
+    await expect(page.getByText('SERP Appears:')).toBeVisible();
+
+    // 4. The surfaced SQL shows both predicate paths: HAVING on the question
+    //    table itself, IN (SELECT ...) membership on a sibling.
+    const questionSql = page
+      .getByTestId('summary-table-question')
+      .getByTestId('widget-sql');
+    await expect(questionSql).toContainText('HAVING');
+    await expect(questionSql).toContainText('count(*) < 5');
+
+    const domainSql = page
+      .getByTestId('summary-table-domain')
+      .getByTestId('widget-sql');
+    await expect(domainSql).toContainText('IN (SELECT');
+
+    // Un-applying restores everything.
+    await page.getByTestId('serp-appearances-apply').uncheck();
+
+    await expect
+      .poll(() => readUniqueQuestionsKpi(page), { timeout: 15000 })
+      .toBe(initialKpi);
+    await expect
+      .poll(() => readFirstQuestionMetric(page), { timeout: 15000 })
+      .toBe(initialTopMetric);
+    await expect(page.getByText('SERP Appears:')).toHaveCount(0);
+  });
+
+  test('SERP filter chip removal also drops the HAVING clause', async ({
+    page,
+  }) => {
+    await initNozzlePaa(page);
+
+    const initialTopMetric = await expect
+      .poll(() => readFirstQuestionMetric(page))
+      .toBeGreaterThan(1)
+      .then(() => readFirstQuestionMetric(page));
+
+    await page.getByTestId('serp-appearances-op').selectOption('lt');
+    await page.getByTestId('serp-appearances-value').fill('5');
+    await page.getByTestId('serp-appearances-apply').check();
+
+    await expect
+      .poll(() => readFirstQuestionMetric(page), { timeout: 15000 })
+      .toBeLessThan(5);
+
+    // Remove via the active-filter chip: the widget un-applies itself and
+    // clears both the membership subquery AND the HAVING clause.
+    await page
+      .getByText('SERP Appears:', { exact: true })
+      .locator('xpath=..')
+      .getByRole('button')
+      .click();
+
+    await expect(page.getByTestId('serp-appearances-apply')).not.toBeChecked();
+    await expect
+      .poll(() => readFirstQuestionMetric(page), { timeout: 15000 })
+      .toBe(initialTopMetric);
+  });
+
+  test('top-page Question Domains filter restricts all widgets via IN (SELECT ...)', async ({
+    page,
+  }) => {
+    await initNozzlePaa(page);
+
+    const initialKpi = await expect
+      .poll(() => readUniqueQuestionsKpi(page))
+      .toBeGreaterThan(0)
+      .then(() => readUniqueQuestionsKpi(page));
+
+    await page.getByTestId('question-min-domains-input').fill('3');
+
+    await expect
+      .poll(() => readUniqueQuestionsKpi(page), { timeout: 15000 })
+      .not.toBe(initialKpi);
+    await expect(page.getByText('Min Domains:')).toBeVisible();
+
+    await page.getByTestId('question-min-domains-input').fill('');
+
+    await expect
+      .poll(() => readUniqueQuestionsKpi(page), { timeout: 15000 })
+      .toBe(initialKpi);
+    await expect(page.getByText('Min Domains:')).toHaveCount(0);
+  });
+});

--- a/examples/react/trimmed/tests/subquery-filters.test.ts
+++ b/examples/react/trimmed/tests/subquery-filters.test.ts
@@ -75,6 +75,7 @@ test.describe('filter-builder subquery filters', () => {
 
     const pageScope = page.getByTestId('page-filter-scope');
     const pageSummary = page.getByTestId('page-roster-summary');
+    const initialPageSummary = await readSummary(pageSummary);
 
     await addFilter(pageScope, 'Country Golds');
     const subqueryRow = page.getByTestId(
@@ -83,6 +84,12 @@ test.describe('filter-builder subquery filters', () => {
     await subqueryRow.getByLabel('page Country Golds value').fill('5');
     await subqueryRow.getByRole('button', { name: 'Apply' }).click();
 
+    // Wait for the subquery filter to actually narrow the roster before
+    // capturing the baseline. `readSummary` only waits for the static
+    // "Visible rows:" label, so reading it immediately after Apply can
+    // capture the still-unfiltered summary under load — which makes the
+    // sibling-context assertion below race against the initial query.
+    await expectSummaryToChange(pageSummary, initialPageSummary);
     const goldsOnlySummary = await readSummary(pageSummary);
 
     // Constrain the sibling sport filter. The subquery factory embeds the

--- a/packages/mosaic-tanstack-react-table/src/filter-builder-types.ts
+++ b/packages/mosaic-tanstack-react-table/src/filter-builder-types.ts
@@ -15,6 +15,8 @@ export type {
   FilterCollection,
   FilterDefinition,
   FilterRuntime,
+  FilterSubqueryFactory,
+  FilterSubqueryFactoryArgs,
   FilterValueKind,
   NumberFilterDefinition,
   NumberRangeFilterDefinition,

--- a/packages/mosaic-tanstack-react-table/src/filter-builder-types.ts
+++ b/packages/mosaic-tanstack-react-table/src/filter-builder-types.ts
@@ -11,14 +11,18 @@ export type {
   DateFilterDefinition,
   DateRangeFilterDefinition,
   FilterBindingState,
+  FilterBuilderDataType,
   FilterCollection,
   FilterDefinition,
   FilterRuntime,
   FilterValueKind,
   NumberFilterDefinition,
   NumberRangeFilterDefinition,
+  ResolvedFilter,
   ScalarMultiselectFilterDefinition,
   SelectFilterDefinition,
+  StoredFilterValue,
+  StoredFilterValueMode,
   TextFilterDefinition,
 } from '@nozzleio/mosaic-tanstack-table-core/filter-builder';
 

--- a/packages/mosaic-tanstack-react-table/src/filter-hook.ts
+++ b/packages/mosaic-tanstack-react-table/src/filter-hook.ts
@@ -16,7 +16,7 @@ export type MosaicTableFilterOptions<TMode extends MosaicTableFilterMode> =
 export function useMosaicTableFilter<TMode extends MosaicTableFilterMode>(
   options: MosaicTableFilterOptions<TMode>,
 ) {
-  const { selection, column, mode, debounceTime, id } = options;
+  const { selection, column, mode, debounceTime, id, subquery } = options;
 
   // 1. Instantiate the controller
   // We use the generic TMode to enforce type safety on the class instance
@@ -27,10 +27,18 @@ export function useMosaicTableFilter<TMode extends MosaicTableFilterMode>(
       mode,
       debounceTime,
       id,
-    });
+    } as MosaicFilterOptions<TMode>);
   }, [selection, column, mode, debounceTime, id]);
 
-  // 2. Cleanup on unmount or reconfiguration
+  // 2. Keep the latest subquery factory attached without invalidating the
+  // filter instance when consumers pass inline lambdas.
+  useEffect(() => {
+    if (subquery) {
+      filter.updateSubquery(subquery);
+    }
+  }, [filter, subquery]);
+
+  // 3. Cleanup on unmount or reconfiguration
   useEffect(() => {
     return () => {
       filter.dispose();

--- a/packages/mosaic-tanstack-react-table/src/filter-scope-hook.ts
+++ b/packages/mosaic-tanstack-react-table/src/filter-scope-hook.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useRegisterSelections } from '@nozzleio/react-mosaic';
 import { Selection } from '@uwdata/mosaic-core';
+import { createClearClause } from '@nozzleio/mosaic-tanstack-table-core';
 import { applyFilterSelection } from '@nozzleio/mosaic-tanstack-table-core/filter-builder';
 
 import {
@@ -18,7 +19,6 @@ import type {
   FilterScope,
   UseMosaicFiltersOptions,
 } from './filter-builder-types';
-import type { SelectionClause } from '@uwdata/mosaic-core';
 
 type LinkedSelection = Selection & { _relay: Set<Selection> };
 
@@ -46,11 +46,7 @@ function clearSeededClauses(
 ) {
   includedSelections.forEach((selection) => {
     selection.clauses.forEach((clause) => {
-      context.update({
-        source: clause.source,
-        value: null,
-        predicate: null,
-      } as SelectionClause);
+      context.update(createClearClause(clause.source));
     });
   });
 }

--- a/packages/mosaic-tanstack-react-table/src/filter-scope-hook.ts
+++ b/packages/mosaic-tanstack-react-table/src/filter-scope-hook.ts
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { useRegisterSelections } from '@nozzleio/react-mosaic';
 import { Selection } from '@uwdata/mosaic-core';
 import { createClearClause } from '@nozzleio/mosaic-tanstack-table-core';
-import { applyFilterSelection } from '@nozzleio/mosaic-tanstack-table-core/filter-builder';
+import {
+  applyFilterSelection,
+  reapplyCommittedFilterSelection,
+} from '@nozzleio/mosaic-tanstack-table-core/filter-builder';
 
 import {
   createFilterScopePersistenceContext,
@@ -154,8 +157,35 @@ export function useMosaicFilters(
       definition,
       selection: selections[definition.id]!,
       scopeId: options.scopeId,
+      // Subquery factories receive sibling-filter context from the scope
+      // context; the filter's own clauses are excluded during resolution.
+      ...(definition.subquery ? { context } : {}),
     }));
-  }, [options.definitions, options.scopeId, selections]);
+  }, [context, options.definitions, options.scopeId, selections]);
+
+  // Rebuild committed subquery predicates when sibling filters change, even
+  // when no filter editor (binding controller) is mounted. The reapply
+  // no-ops when the rebuilt predicate is unchanged, so converged states
+  // publish nothing and feedback loops terminate.
+  React.useEffect(() => {
+    const cleanups = runtimes
+      .filter((runtime) => runtime.definition.subquery && runtime.context)
+      .map((runtime) => {
+        const scopeContext = runtime.context!;
+        const listener = () => {
+          reapplyCommittedFilterSelection(runtime);
+        };
+
+        scopeContext.addEventListener('value', listener);
+        return () => {
+          scopeContext.removeEventListener('value', listener);
+        };
+      });
+
+    return () => {
+      cleanups.forEach((cleanup) => cleanup());
+    };
+  }, [runtimes]);
 
   const runtimeMap = React.useMemo(() => {
     return new Map(runtimes.map((runtime) => [runtime.definition.id, runtime]));

--- a/packages/mosaic-tanstack-react-table/src/helpers.ts
+++ b/packages/mosaic-tanstack-react-table/src/helpers.ts
@@ -1,8 +1,19 @@
 export {
+  buildSubqueryPredicate,
   coerceDate,
   coerceNumber,
   coerceSafeTimestamp,
+  createClearClause,
   createMosaicColumnHelper,
   createMosaicMapping,
+  createSubqueryClause,
+  createValueClause,
   isRangeTuple,
+  normalizeSubqueryFilterQuery,
+} from '@nozzleio/mosaic-tanstack-table-core';
+export type {
+  BuildSubqueryPredicateOptions,
+  SubqueryClauseSpec,
+  SubqueryFilterQuery,
+  ValueClauseSpec,
 } from '@nozzleio/mosaic-tanstack-table-core';

--- a/packages/mosaic-tanstack-react-table/tests/public-api.test.ts
+++ b/packages/mosaic-tanstack-react-table/tests/public-api.test.ts
@@ -95,7 +95,7 @@ test('publishes a hook-only inputs surface', () => {
 
 test('publishes the narrowed adapter hook contracts', () => {
   expectTypeOf<MosaicTableFilterMode>().toEqualTypeOf<
-    'TEXT' | 'MATCH' | 'SELECT' | 'DATE_RANGE' | 'RANGE'
+    'TEXT' | 'MATCH' | 'SELECT' | 'DATE_RANGE' | 'RANGE' | 'SUBQUERY'
   >();
   expectTypeOf<
     MosaicTableFilterOptions<'TEXT'>['mode']

--- a/packages/mosaic-tanstack-table-core/src/aggregation-bridge.ts
+++ b/packages/mosaic-tanstack-table-core/src/aggregation-bridge.ts
@@ -3,6 +3,7 @@
  * Used for "Cross-Filtering Aggregations" where a summary table filters a detail table via a subquery.
  */
 
+import { createClearClause, createValueClause } from './clause-factory';
 import type { Selection, SelectionClause } from '@uwdata/mosaic-core';
 import type { FilterExpr } from '@uwdata/mosaic-sql';
 import type { SelectionSource } from './types';
@@ -57,11 +58,7 @@ export class AggregationBridge {
     if (!inputPred || inputPred.toString() === 'true') {
       // Only clear if not already empty to avoid loops
       if (outputSelection.value !== null) {
-        outputSelection.update({
-          source,
-          value: null,
-          predicate: null,
-        });
+        outputSelection.update(createClearClause(source));
       }
       return;
     }
@@ -73,11 +70,13 @@ export class AggregationBridge {
     );
 
     // 3. Update Output
-    outputSelection.update({
-      source,
-      value: 'custom', // Arbitrary value, we rely on the predicate
-      predicate: resultPredicate as SelectionClause['predicate'],
-    });
+    outputSelection.update(
+      createValueClause({
+        source,
+        value: 'custom', // Arbitrary value, we rely on the predicate
+        predicate: resultPredicate as SelectionClause['predicate'],
+      }),
+    );
   };
 
   /**

--- a/packages/mosaic-tanstack-table-core/src/clause-factory.ts
+++ b/packages/mosaic-tanstack-table-core/src/clause-factory.ts
@@ -1,0 +1,67 @@
+/**
+ * Central construction point for the Selection clauses this package writes
+ * via `selection.update(...)`.
+ *
+ * Mosaic Selection clauses are predicate-shape agnostic, but the clause
+ * `meta` field is not: Mosaic's PreAggregator assumes `meta.type: 'point'`
+ * predicates are simple column tests and `interval` predicates are exactly
+ * BETWEEN-shaped. Routing all clause construction through this module keeps
+ * the `meta` policy in one place:
+ *
+ * - VALUE clauses (this module today): predicates built from literal values
+ *   (comparisons, IN lists, LIKE patterns, list functions). These may carry
+ *   optimizer `meta` hints.
+ * - SUBQUERY clauses (future): predicates embedding scalar subqueries
+ *   (e.g. `col IN (SELECT ...)`). These must NEVER carry `meta`; without it
+ *   Mosaic safely falls back to the standard (non pre-aggregated) query path.
+ */
+import type {
+  ClauseMetadata,
+  ClauseSource,
+  MosaicClient,
+  SelectionClause,
+} from '@uwdata/mosaic-core';
+
+export interface ValueClauseSpec {
+  /** Unique identity for the clause (object equality). One clause per source. */
+  source: ClauseSource;
+  /** Clients that should NOT be re-queried by this clause (cross-filter semantics). */
+  clients?: Set<MosaicClient>;
+  /** App-level value associated with the clause; not used for SQL generation. */
+  value: unknown;
+  /** SQL predicate; `null` removes the source's clause from the Selection. */
+  predicate: SelectionClause['predicate'];
+  /**
+   * Optional optimizer hints. Only valid for predicates built from literal
+   * values; never attach `meta` to subquery-bearing predicates.
+   */
+  meta?: ClauseMetadata;
+}
+
+/**
+ * Builds a Selection clause whose predicate is derived from literal values.
+ */
+export function createValueClause(spec: ValueClauseSpec): SelectionClause {
+  return {
+    source: spec.source,
+    clients: spec.clients,
+    value: spec.value,
+    predicate: spec.predicate,
+    meta: spec.meta,
+  };
+}
+
+/**
+ * Builds a clause that removes the source's active clause from a Selection.
+ */
+export function createClearClause(
+  source: ClauseSource,
+  clients?: Set<MosaicClient>,
+): SelectionClause {
+  return {
+    source,
+    clients,
+    value: null,
+    predicate: null,
+  };
+}

--- a/packages/mosaic-tanstack-table-core/src/clause-factory.ts
+++ b/packages/mosaic-tanstack-table-core/src/clause-factory.ts
@@ -52,6 +52,31 @@ export function createValueClause(spec: ValueClauseSpec): SelectionClause {
 }
 
 /**
+ * A clause spec for subquery-bearing predicates. Identical to
+ * {@link ValueClauseSpec} except that `meta` is structurally forbidden:
+ * Mosaic's PreAggregator assumes `point`/`interval` predicates have simple
+ * value-test shapes, and a subquery predicate tagged that way produces
+ * incorrect optimized queries. Without `meta`, Mosaic safely uses the
+ * standard query path.
+ */
+export type SubqueryClauseSpec = Omit<ValueClauseSpec, 'meta'>;
+
+/**
+ * Builds a Selection clause whose predicate embeds a scalar subquery
+ * (e.g. `col IN (SELECT ...)`). Never attaches optimizer `meta`.
+ */
+export function createSubqueryClause(
+  spec: SubqueryClauseSpec,
+): SelectionClause {
+  return {
+    source: spec.source,
+    clients: spec.clients,
+    value: spec.value,
+    predicate: spec.predicate,
+  };
+}
+
+/**
  * Builds a clause that removes the source's active clause from a Selection.
  */
 export function createClearClause(

--- a/packages/mosaic-tanstack-table-core/src/data-table.ts
+++ b/packages/mosaic-tanstack-table-core/src/data-table.ts
@@ -24,6 +24,7 @@ import {
   extractInternalFilters,
 } from './query/query-builder';
 import { applyRoutedFilters, routeFilter } from './query/filter-routing';
+import { createValueClause } from './clause-factory';
 import { MosaicSelectionManager } from './selection-manager';
 import { createLifecycleManager, handleQueryError } from './client-utils';
 import { SidecarManager } from './sidecar-manager';
@@ -309,12 +310,14 @@ export class MosaicDataTable<
     }
 
     const clause = row ? this.#createRowIdentityClause(row) : null;
-    this.options.highlightBy.update({
-      source: this,
-      clients: new Set([this]),
-      value: clause?.value ?? null,
-      predicate: (clause?.predicate ?? null) as SelectionClause['predicate'],
-    });
+    this.options.highlightBy.update(
+      createValueClause({
+        source: this,
+        clients: new Set([this]),
+        value: clause?.value ?? null,
+        predicate: (clause?.predicate ?? null) as SelectionClause['predicate'],
+      }),
+    );
   }
 
   public selectRow(row: TData | null): void {
@@ -518,11 +521,13 @@ export class MosaicDataTable<
       const predicate =
         tablePredicates.length > 0 ? mSql.and(...tablePredicates) : null;
 
-      this.tableFilterSelection.update({
-        source: this,
-        value: tableState.columnFilters,
-        predicate,
-      });
+      this.tableFilterSelection.update(
+        createValueClause({
+          source: this,
+          value: tableState.columnFilters,
+          predicate,
+        }),
+      );
     } else {
       statement.limit(tableState.pagination.pageSize || 50);
       if (tableState.pagination.pageIndex > 0) {
@@ -1092,11 +1097,13 @@ export class MosaicDataTable<
     });
 
     this.#groupedController.reset();
-    this.tableFilterSelection.update({
-      source: this,
-      value: [],
-      predicate: null,
-    });
+    this.tableFilterSelection.update(
+      createValueClause({
+        source: this,
+        value: [],
+        predicate: null,
+      }),
+    );
   }
 
   #configureRowSelection(options: MosaicDataTableOptions<TData, TValue>): void {

--- a/packages/mosaic-tanstack-table-core/src/data-table.ts
+++ b/packages/mosaic-tanstack-table-core/src/data-table.ts
@@ -213,6 +213,11 @@ export class MosaicDataTable<
         preaggregator?: { clear: () => void };
       }
     ).preaggregator?.clear();
+    // @internal @experimental debug surface; see MosaicDataTableStore._lastQuery
+    this.store.setState((previousState) => ({
+      ...previousState,
+      _lastQuery: String(statement),
+    }));
     this.queryPending();
     this._pending = Promise.resolve(this.coordinator.query(statement))
       .then((data) => {

--- a/packages/mosaic-tanstack-table-core/src/filter-builder/binding-controller.ts
+++ b/packages/mosaic-tanstack-table-core/src/filter-builder/binding-controller.ts
@@ -4,6 +4,7 @@ import {
   areFilterBindingStatesEqual,
   clearFilterSelection,
   readFilterSelectionState,
+  reapplyCommittedFilterSelection,
 } from './helpers';
 import type { Store } from '@tanstack/store';
 
@@ -40,6 +41,7 @@ export class FilterBindingController {
 
   #isConnected = false;
   #syncVersion = 0;
+  #contextVersion = 0;
   #selectionListener = () => {
     const syncVersion = ++this.#syncVersion;
 
@@ -49,6 +51,21 @@ export class FilterBindingController {
       }
 
       this.syncFromSelection();
+    });
+  };
+
+  // Rebuilds a committed subquery predicate when sibling context changes.
+  // Safe against feedback loops: the reapply no-ops when the rebuilt
+  // predicate is unchanged, so a converged state publishes nothing.
+  #contextListener = () => {
+    const contextVersion = ++this.#contextVersion;
+
+    queueMicrotask(() => {
+      if (!this.#isConnected || contextVersion !== this.#contextVersion) {
+        return;
+      }
+
+      reapplyCommittedFilterSelection(this.runtime, this.filterClauseTarget);
     });
   };
 
@@ -143,7 +160,13 @@ export class FilterBindingController {
 
     this.#isConnected = true;
     this.#syncVersion += 1;
+    this.#contextVersion += 1;
     this.runtime.selection.addEventListener('value', this.#selectionListener);
+
+    if (this.#shouldTrackContext()) {
+      this.runtime.context?.addEventListener('value', this.#contextListener);
+    }
+
     this.syncFromSelection();
   };
 
@@ -154,11 +177,22 @@ export class FilterBindingController {
 
     this.#isConnected = false;
     this.#syncVersion += 1;
+    this.#contextVersion += 1;
     this.runtime.selection.removeEventListener(
       'value',
       this.#selectionListener,
     );
+
+    if (this.#shouldTrackContext()) {
+      this.runtime.context?.removeEventListener('value', this.#contextListener);
+    }
   };
+
+  #shouldTrackContext(): boolean {
+    return (
+      this.runtime.definition.subquery != null && this.runtime.context != null
+    );
+  }
 
   dispose = (): void => {
     this.disconnect();

--- a/packages/mosaic-tanstack-table-core/src/filter-builder/helpers.ts
+++ b/packages/mosaic-tanstack-table-core/src/filter-builder/helpers.ts
@@ -1,9 +1,18 @@
+import { and } from '@uwdata/mosaic-sql';
 import {
   buildCollectionPredicate,
   buildConditionPredicate,
   buildEmptyValuePredicate,
 } from '../condition-predicate';
-import { createClearClause, createValueClause } from '../clause-factory';
+import {
+  buildSubqueryPredicate,
+  normalizeSubqueryFilterQuery,
+} from '../subquery-predicate';
+import {
+  createClearClause,
+  createSubqueryClause,
+  createValueClause,
+} from '../clause-factory';
 
 import type {
   ColumnType,
@@ -13,6 +22,7 @@ import type {
 } from '../types';
 import type { SqlFilterClauseTarget } from '../query/filter-routing';
 import type { Selection, SelectionClause } from '@uwdata/mosaic-core';
+import type { ExprNode } from '@uwdata/mosaic-sql';
 import type {
   FilterBindingState,
   FilterBuilderDataType,
@@ -236,7 +246,7 @@ function normalizeStoredValue(
  * into condition values.
  */
 const SUPPORTED_STORED_FILTER_VALUE_MODES: ReadonlySet<StoredFilterValueMode> =
-  new Set(['CONDITION']);
+  new Set(['CONDITION', 'SUBQUERY']);
 
 /**
  * True for any value that carries a stored-filter-value `mode` discriminator,
@@ -599,6 +609,36 @@ export function normalizeFilterBindingState(
   };
 }
 
+/**
+ * Resolves the AND of sibling-filter predicates from the runtime's `context`
+ * Selection, excluding any clause sourced by this filter itself.
+ */
+function resolveSubqueryContextPredicate(
+  filter: FilterRuntime,
+): ExprNode | null {
+  const context = filter.context;
+
+  if (!context) {
+    return null;
+  }
+
+  const source = getFilterSource(filter);
+  const predicates = context.clauses
+    .filter((clause) => clause.source !== source)
+    .map((clause) => clause.predicate)
+    .filter((predicate): predicate is ExprNode => predicate != null);
+
+  if (predicates.length === 0) {
+    return null;
+  }
+
+  if (predicates.length === 1) {
+    return predicates[0] ?? null;
+  }
+
+  return and(...predicates);
+}
+
 function resolveAppliedFilterSelection(
   filter: FilterRuntime,
   state: FilterBindingState,
@@ -622,20 +662,29 @@ function resolveAppliedFilterSelection(
     }
   }
 
-  const resolvedOperator = resolveOperatorAlias(
-    filter.definition,
-    operator,
-    state.value,
-    state.valueTo,
-  );
+  const resolvedFilter: ResolvedFilter | null = filter.definition.subquery
+    ? {
+        kind: 'subquery',
+        state: {
+          operator,
+          value: normalizedValue,
+          valueTo: state.valueTo ?? null,
+        },
+      }
+    : resolveOperatorAlias(
+        filter.definition,
+        operator,
+        state.value,
+        state.valueTo,
+      );
 
-  if (!resolvedOperator) {
+  if (!resolvedFilter) {
     return null;
   }
 
   const predicate = buildResolvedPredicate(
     filter,
-    resolvedOperator,
+    resolvedFilter,
   ) as SelectionClause['predicate'];
 
   if (!predicate) {
@@ -707,7 +756,7 @@ function createStoredFilterValue(
   state: FilterBindingState,
 ): StoredFilterValue {
   return {
-    mode: 'CONDITION',
+    mode: filter.definition.subquery ? 'SUBQUERY' : 'CONDITION',
     operator: state.operator,
     value: state.value,
     valueTo: state.valueTo,
@@ -775,6 +824,30 @@ function buildResolvedPredicate(
         match: resolvedFilter.match,
         negate: resolvedFilter.negate,
       });
+    case 'subquery': {
+      const factory = filter.definition.subquery;
+
+      if (!factory) {
+        return undefined;
+      }
+
+      const normalized = normalizeSubqueryFilterQuery(
+        factory({
+          state: resolvedFilter.state,
+          contextPredicate: resolveSubqueryContextPredicate(filter),
+        }),
+      );
+
+      if (!normalized) {
+        return undefined;
+      }
+
+      return buildSubqueryPredicate({
+        column: filter.definition.column,
+        query: normalized.query,
+        negate: normalized.negate,
+      });
+    }
     default: {
       const exhaustive: never = resolvedFilter;
       return exhaustive;
@@ -796,24 +869,74 @@ export function applyFilterSelection(
 
   switch (target) {
     case 'where':
-    case 'having':
-      filter.selection.update(
-        createValueClause({
-          source: getFilterSource(filter),
-          value: createStoredFilterValue(filter, {
-            operator: resolvedSelection.operator,
-            value: resolvedSelection.normalizedValue,
-            valueTo: state.valueTo,
-          }),
-          predicate: resolvedSelection.predicate,
+    case 'having': {
+      const clauseSpec = {
+        source: getFilterSource(filter),
+        value: createStoredFilterValue(filter, {
+          operator: resolvedSelection.operator,
+          value: resolvedSelection.normalizedValue,
+          valueTo: state.valueTo,
         }),
+        predicate: resolvedSelection.predicate,
+      };
+
+      // Subquery predicates must never carry optimizer `meta`; route them
+      // through the dedicated clause constructor.
+      filter.selection.update(
+        filter.definition.subquery
+          ? createSubqueryClause(clauseSpec)
+          : createValueClause(clauseSpec),
       );
       break;
+    }
     default: {
       const exhaustive: never = target;
       return exhaustive;
     }
   }
+}
+
+/**
+ * Re-resolves a filter's committed state and republishes its clause when the
+ * resulting predicate changed (e.g. a subquery factory embedding sibling
+ * context after the context changed).
+ *
+ * No-ops when the filter has no committed state or the predicate is
+ * unchanged, which makes it safe to call from change listeners: a republish
+ * that converges produces no further updates.
+ *
+ * @returns true when an updated clause was published.
+ */
+export function reapplyCommittedFilterSelection(
+  filter: FilterRuntime,
+  target: SqlFilterClauseTarget = 'where',
+): boolean {
+  const { hasCommittedState, state } = readResolvedFilterSelectionState(filter);
+
+  if (!hasCommittedState) {
+    return false;
+  }
+
+  const resolvedSelection = resolveAppliedFilterSelection(filter, state);
+
+  if (!resolvedSelection) {
+    return false;
+  }
+
+  const source = getFilterSource(filter);
+  const currentClause = filter.selection.clauses.find(
+    (clause) => clause.source === source,
+  );
+
+  if (
+    currentClause?.predicate != null &&
+    String(currentClause.predicate) === String(resolvedSelection.predicate)
+  ) {
+    return false;
+  }
+
+  applyFilterSelection(filter, state, target);
+  return true;
 }
 
 export function getFacetSelectedValues(

--- a/packages/mosaic-tanstack-table-core/src/filter-builder/helpers.ts
+++ b/packages/mosaic-tanstack-table-core/src/filter-builder/helpers.ts
@@ -897,6 +897,12 @@ export function applyFilterSelection(
 }
 
 /**
+ * Selections whose committed clause is mid-publish. Guards against the
+ * synchronous reentrancy described in {@link reapplyCommittedFilterSelection}.
+ */
+const reapplyInProgress = new WeakSet<Selection>();
+
+/**
  * Re-resolves a filter's committed state and republishes its clause when the
  * resulting predicate changed (e.g. a subquery factory embedding sibling
  * context after the context changed).
@@ -935,7 +941,26 @@ export function reapplyCommittedFilterSelection(
     return false;
   }
 
-  applyFilterSelection(filter, state, target);
+  // Publishing the rebuilt clause relays synchronously back through any
+  // downstream scope context (Mosaic's `Selection.update` relays before it
+  // commits its own value). Listeners wired to that context — including the
+  // one that drives this reapply — therefore re-enter before
+  // `filter.selection.clauses` reflects the value we just published, so the
+  // convergence guard above still sees the stale predicate and would
+  // republish indefinitely. Suppress reentrant reapplies for this selection
+  // while the publish settles; the outer call already publishes the final
+  // predicate.
+  if (reapplyInProgress.has(filter.selection)) {
+    return false;
+  }
+
+  reapplyInProgress.add(filter.selection);
+  try {
+    applyFilterSelection(filter, state, target);
+  } finally {
+    reapplyInProgress.delete(filter.selection);
+  }
+
   return true;
 }
 

--- a/packages/mosaic-tanstack-table-core/src/filter-builder/helpers.ts
+++ b/packages/mosaic-tanstack-table-core/src/filter-builder/helpers.ts
@@ -3,6 +3,7 @@ import {
   buildConditionPredicate,
   buildEmptyValuePredicate,
 } from '../condition-predicate';
+import { createClearClause, createValueClause } from '../clause-factory';
 
 import type {
   ColumnType,
@@ -14,44 +15,14 @@ import type { SqlFilterClauseTarget } from '../query/filter-routing';
 import type { Selection, SelectionClause } from '@uwdata/mosaic-core';
 import type {
   FilterBindingState,
+  FilterBuilderDataType,
   FilterDefinition,
   FilterRuntime,
   FilterValueKind,
+  ResolvedFilter,
+  StoredFilterValue,
+  StoredFilterValueMode,
 } from './types';
-
-type FilterBuilderDataType = 'string' | 'number' | 'date' | 'boolean';
-
-type ResolvedFilter =
-  | {
-      kind: 'condition';
-      operator: FilterOperator;
-      value?: ConditionValue | null;
-      valueTo?: ConditionComparableValue | null;
-    }
-  | {
-      kind: 'collection';
-      columnType: ColumnType;
-      dataType: FilterBuilderDataType;
-      values: Array<ConditionComparableValue>;
-      match: 'any' | 'all';
-      negate: boolean;
-    }
-  | {
-      kind: 'empty';
-      columnType: ColumnType;
-      dataType: FilterBuilderDataType;
-      negate: boolean;
-    };
-
-type StoredFilterValue = {
-  mode: 'CONDITION';
-  operator: string | null;
-  value?: unknown;
-  valueTo?: unknown;
-  dataType?: FilterBuilderDataType;
-  filterId: string;
-  scopeId: string;
-};
 
 type FilterBuilderSource = {
   id: string;
@@ -258,12 +229,34 @@ function normalizeStoredValue(
   return value ?? null;
 }
 
-function isStoredFilterValue(value: unknown): value is StoredFilterValue {
+/**
+ * Stored-value modes this version of the filter builder can resolve into
+ * predicates. Values carrying other modes are "stored but unsupported": they
+ * are recognized as stored filter values (and left alone) but never coerced
+ * into condition values.
+ */
+const SUPPORTED_STORED_FILTER_VALUE_MODES: ReadonlySet<StoredFilterValueMode> =
+  new Set(['CONDITION']);
+
+/**
+ * True for any value that carries a stored-filter-value `mode` discriminator,
+ * including modes this version does not understand.
+ */
+function isStoredFilterValueLike(
+  value: unknown,
+): value is { mode: string } & Record<string, unknown> {
   return (
     typeof value === 'object' &&
     value !== null &&
     'mode' in value &&
-    value.mode === 'CONDITION'
+    typeof value.mode === 'string'
+  );
+}
+
+function isStoredFilterValue(value: unknown): value is StoredFilterValue {
+  return (
+    isStoredFilterValueLike(value) &&
+    SUPPORTED_STORED_FILTER_VALUE_MODES.has(value.mode as StoredFilterValueMode)
   );
 }
 
@@ -583,6 +576,13 @@ export function normalizeFilterBindingState(
     };
   }
 
+  if (isStoredFilterValueLike(rawValue)) {
+    // Stored filter value with an unsupported mode (e.g. written by a newer
+    // version or a different filter family). Never coerce the envelope
+    // itself into a condition value.
+    return fallbackState;
+  }
+
   if (isRangeValueKind(definition.valueKind)) {
     const [rangeFrom, rangeTo] = normalizeRangeTuple(rawValue, null);
     return {
@@ -731,11 +731,7 @@ export function clearFilterSelection(
   switch (target) {
     case 'where':
     case 'having':
-      filter.selection.update({
-        source: getFilterSource(filter),
-        value: null,
-        predicate: null,
-      });
+      filter.selection.update(createClearClause(getFilterSource(filter)));
       break;
     default: {
       const exhaustive: never = target;
@@ -779,6 +775,10 @@ function buildResolvedPredicate(
         match: resolvedFilter.match,
         negate: resolvedFilter.negate,
       });
+    default: {
+      const exhaustive: never = resolvedFilter;
+      return exhaustive;
+    }
   }
 }
 
@@ -797,15 +797,17 @@ export function applyFilterSelection(
   switch (target) {
     case 'where':
     case 'having':
-      filter.selection.update({
-        source: getFilterSource(filter),
-        value: createStoredFilterValue(filter, {
-          operator: resolvedSelection.operator,
-          value: resolvedSelection.normalizedValue,
-          valueTo: state.valueTo,
+      filter.selection.update(
+        createValueClause({
+          source: getFilterSource(filter),
+          value: createStoredFilterValue(filter, {
+            operator: resolvedSelection.operator,
+            value: resolvedSelection.normalizedValue,
+            valueTo: state.valueTo,
+          }),
+          predicate: resolvedSelection.predicate,
         }),
-        predicate: resolvedSelection.predicate,
-      });
+      );
       break;
     default: {
       const exhaustive: never = target;

--- a/packages/mosaic-tanstack-table-core/src/filter-builder/types.ts
+++ b/packages/mosaic-tanstack-table-core/src/filter-builder/types.ts
@@ -1,4 +1,11 @@
-import type { ColumnType, FacetSortMode, MosaicTableSource } from '../types';
+import type {
+  ColumnType,
+  ConditionComparableValue,
+  ConditionValue,
+  FacetSortMode,
+  FilterOperator,
+  MosaicTableSource,
+} from '../types';
 import type { Selection } from '@uwdata/mosaic-core';
 import type {
   ArrayMultiselectConditionOperatorId,
@@ -21,6 +28,61 @@ export type FilterValueKind =
   | 'number'
   | 'number-range';
 
+export type FilterBuilderDataType = 'string' | 'number' | 'date' | 'boolean';
+
+/**
+ * Discriminator for the app-level values stored on filter-builder Selection
+ * clauses. `CONDITION` covers all predicates built from literal values.
+ *
+ * Future modes (e.g. subquery-backed filters) extend this union; readers must
+ * treat unrecognized modes as "stored but unsupported" and never coerce them
+ * into condition values.
+ */
+export type StoredFilterValueMode = 'CONDITION';
+
+/**
+ * The app-level value written to a filter-builder Selection clause. This is
+ * what `selection.valueFor(source)` returns and what persisters serialize, so
+ * it must remain JSON-serializable.
+ */
+export type StoredFilterValue = {
+  mode: StoredFilterValueMode;
+  operator: string | null;
+  value?: unknown;
+  valueTo?: unknown;
+  dataType?: FilterBuilderDataType;
+  filterId: string;
+  scopeId: string;
+};
+
+/**
+ * Normalized predicate request produced by operator-alias resolution and
+ * consumed by predicate building. Each `kind` maps to one predicate builder;
+ * the dispatch is exhaustive, so adding a kind (e.g. `subquery`) is a
+ * compile-driven change.
+ */
+export type ResolvedFilter =
+  | {
+      kind: 'condition';
+      operator: FilterOperator;
+      value?: ConditionValue | null;
+      valueTo?: ConditionComparableValue | null;
+    }
+  | {
+      kind: 'collection';
+      columnType: ColumnType;
+      dataType: FilterBuilderDataType;
+      values: Array<ConditionComparableValue>;
+      match: 'any' | 'all';
+      negate: boolean;
+    }
+  | {
+      kind: 'empty';
+      columnType: ColumnType;
+      dataType: FilterBuilderDataType;
+      negate: boolean;
+    };
+
 type FilterDefinitionBase<
   TValueKind extends FilterValueKind,
   TOperator extends FilterOperatorId,
@@ -31,7 +93,7 @@ type FilterDefinitionBase<
   valueKind: TValueKind;
   operators: Array<TOperator>;
   defaultOperator?: TOperator;
-  dataType?: 'string' | 'number' | 'date' | 'boolean';
+  dataType?: FilterBuilderDataType;
   groupId?: string;
   description?: string;
   columnType?: ColumnType;

--- a/packages/mosaic-tanstack-table-core/src/filter-builder/types.ts
+++ b/packages/mosaic-tanstack-table-core/src/filter-builder/types.ts
@@ -6,7 +6,9 @@ import type {
   FilterOperator,
   MosaicTableSource,
 } from '../types';
+import type { SubqueryFilterQuery } from '../subquery-predicate';
 import type { Selection } from '@uwdata/mosaic-core';
+import type { ExprNode } from '@uwdata/mosaic-sql';
 import type {
   ArrayMultiselectConditionOperatorId,
   DateConditionOperatorId,
@@ -32,13 +34,14 @@ export type FilterBuilderDataType = 'string' | 'number' | 'date' | 'boolean';
 
 /**
  * Discriminator for the app-level values stored on filter-builder Selection
- * clauses. `CONDITION` covers all predicates built from literal values.
+ * clauses. `CONDITION` covers all predicates built from literal values;
+ * `SUBQUERY` marks values whose predicate is rebuilt through the
+ * definition's `subquery` factory.
  *
- * Future modes (e.g. subquery-backed filters) extend this union; readers must
- * treat unrecognized modes as "stored but unsupported" and never coerce them
- * into condition values.
+ * Future modes extend this union; readers must treat unrecognized modes as
+ * "stored but unsupported" and never coerce them into condition values.
  */
-export type StoredFilterValueMode = 'CONDITION';
+export type StoredFilterValueMode = 'CONDITION' | 'SUBQUERY';
 
 /**
  * The app-level value written to a filter-builder Selection clause. This is
@@ -81,7 +84,39 @@ export type ResolvedFilter =
       columnType: ColumnType;
       dataType: FilterBuilderDataType;
       negate: boolean;
+    }
+  | {
+      kind: 'subquery';
+      /** The committed binding state handed to the definition's `subquery` factory. */
+      state: FilterBindingState;
     };
+
+/** Arguments passed to a filter definition's `subquery` factory. */
+export interface FilterSubqueryFactoryArgs {
+  /** The committed binding state (operator, value, valueTo). */
+  state: FilterBindingState;
+  /**
+   * The AND of sibling filter predicates from the runtime's `context`
+   * Selection, with this filter's own clause excluded. `null` when no
+   * context is attached or no sibling filters are active.
+   *
+   * Mosaic does not push other Selection clauses into scalar subqueries;
+   * embed this predicate in the subquery if it should respect sibling
+   * filters. The clause is rebuilt automatically when the context changes.
+   */
+  contextPredicate: ExprNode | null;
+}
+
+/**
+ * Builds the membership subquery for a subquery-backed filter definition.
+ * The resulting predicate is `definition.column [NOT] IN (<query>)`.
+ *
+ * Must be pure and cheap: it runs on every apply, on hydration, and during
+ * committed-state reads.
+ */
+export type FilterSubqueryFactory = (
+  args: FilterSubqueryFactoryArgs,
+) => SubqueryFilterQuery;
 
 type FilterDefinitionBase<
   TValueKind extends FilterValueKind,
@@ -97,6 +132,17 @@ type FilterDefinitionBase<
   groupId?: string;
   description?: string;
   columnType?: ColumnType;
+  /**
+   * When present, this filter's predicate is built as
+   * `column [NOT] IN (<subquery>)` instead of a literal-value condition: the
+   * factory receives the committed binding state (and sibling context, when
+   * a runtime `context` Selection is attached) and returns the membership
+   * query. Operator/value semantics are interpreted by the factory.
+   *
+   * The binding state stays JSON-serializable, so persistence works
+   * unchanged: hydration rebuilds the predicate through this factory.
+   */
+  subquery?: FilterSubqueryFactory;
   facet?: {
     table: MosaicTableSource;
     sortMode?: FacetSortMode;
@@ -169,6 +215,17 @@ export interface FilterRuntime {
   definition: FilterDefinition;
   selection: Selection;
   scopeId: string;
+  /**
+   * Optional Selection providing sibling-filter context to this filter's
+   * `subquery` factory (e.g. the scope's composed context). Clauses sourced
+   * by this filter itself are excluded automatically, so passing a context
+   * that mirrors the filter's own selection is safe.
+   *
+   * When attached, subquery predicates are rebuilt whenever the context
+   * changes. Avoid making two subquery filters mutually context-dependent:
+   * each rebuild embeds the other's previous predicate and never converges.
+   */
+  context?: Selection;
 }
 
 export interface FilterBindingState {

--- a/packages/mosaic-tanstack-table-core/src/filter-client.ts
+++ b/packages/mosaic-tanstack-table-core/src/filter-client.ts
@@ -2,8 +2,17 @@ import { MosaicClient } from '@uwdata/mosaic-core';
 import * as mSql from '@uwdata/mosaic-sql';
 import { createStructAccess } from './utils';
 import { SqlIdentifier } from './domain/sql-identifier';
-import { createClearClause, createValueClause } from './clause-factory';
+import {
+  createClearClause,
+  createSubqueryClause,
+  createValueClause,
+} from './clause-factory';
+import {
+  buildSubqueryPredicate,
+  normalizeSubqueryFilterQuery,
+} from './subquery-predicate';
 import type { Selection, SelectionClause } from '@uwdata/mosaic-core';
+import type { SubqueryFilterQuery } from './subquery-predicate';
 import type { FilterInput, FilterMode } from './types';
 
 type FilterValueFor<TMode extends FilterMode> = Extract<
@@ -11,7 +20,15 @@ type FilterValueFor<TMode extends FilterMode> = Extract<
   { mode: TMode }
 >['value'];
 
-export interface MosaicFilterOptions<TMode extends FilterMode> {
+/**
+ * Builds the membership subquery for a SUBQUERY-mode filter from the
+ * filter's current value. Must be pure: it re-runs on every apply.
+ */
+export type MosaicFilterSubqueryFactory<TValue = unknown> = (
+  value: TValue,
+) => SubqueryFilterQuery;
+
+export type MosaicFilterOptions<TMode extends FilterMode> = {
   /** The selection instance to update */
   selection: Selection;
   /** The SQL column name (or struct path "a.b") */
@@ -22,7 +39,17 @@ export interface MosaicFilterOptions<TMode extends FilterMode> {
   debounceTime?: number;
   /** Optional ID for the selection clause */
   id?: string;
-}
+} & (TMode extends 'SUBQUERY'
+  ? {
+      /**
+       * Builds the membership subquery from the filter value. Required for
+       * SUBQUERY mode; the predicate becomes `column [NOT] IN (<query>)`.
+       */
+      subquery: MosaicFilterSubqueryFactory<FilterValueFor<TMode>>;
+    }
+  : {
+      subquery?: never;
+    });
 
 /**
  * A headless controller for managing filter inputs.
@@ -37,6 +64,9 @@ export class MosaicFilter<TMode extends FilterMode> extends MosaicClient {
   public filterId: string;
 
   private timer: ReturnType<typeof setTimeout> | null = null;
+  // Stored with a widened value type; the public options type enforces the
+  // strict pairing between TMode and the factory's value parameter.
+  private subqueryFactory: MosaicFilterSubqueryFactory | undefined;
 
   constructor(options: MosaicFilterOptions<TMode>) {
     super(options.selection);
@@ -45,6 +75,20 @@ export class MosaicFilter<TMode extends FilterMode> extends MosaicClient {
     this.mode = options.mode;
     this.debounceTime = options.debounceTime ?? 300;
     this.filterId = options.id || `filter-${options.column}`;
+    this.subqueryFactory = options.subquery as
+      | MosaicFilterSubqueryFactory
+      | undefined;
+  }
+
+  /**
+   * Replaces the subquery factory used by SUBQUERY mode. Useful when the
+   * factory closes over changing state (e.g. inline lambdas in UI code).
+   * Does not re-apply the current value.
+   */
+  public updateSubquery(
+    subquery: MosaicFilterSubqueryFactory<FilterValueFor<TMode>>,
+  ): void {
+    this.subqueryFactory = subquery as MosaicFilterSubqueryFactory;
   }
 
   /**
@@ -66,13 +110,18 @@ export class MosaicFilter<TMode extends FilterMode> extends MosaicClient {
    */
   public apply(value: FilterValueFor<TMode>) {
     const predicate = this.generatePredicate(value);
+    const spec = {
+      source: this,
+      value: value,
+      predicate,
+    };
 
+    // Subquery predicates must never carry optimizer `meta`; route them
+    // through the dedicated clause constructor.
     this.selection.update(
-      createValueClause({
-        source: this,
-        value: value,
-        predicate,
-      }),
+      this.mode === 'SUBQUERY'
+        ? createSubqueryClause(spec)
+        : createValueClause(spec),
     );
   }
 
@@ -148,6 +197,26 @@ export class MosaicFilter<TMode extends FilterMode> extends MosaicClient {
           }
         }
         return null;
+      }
+
+      case 'SUBQUERY': {
+        if (!this.subqueryFactory) {
+          return null;
+        }
+
+        const normalized = normalizeSubqueryFilterQuery(
+          this.subqueryFactory(value),
+        );
+
+        if (!normalized) {
+          return null;
+        }
+
+        return buildSubqueryPredicate({
+          column: this.column,
+          query: normalized.query,
+          negate: normalized.negate,
+        });
       }
 
       case 'CONDITION': {

--- a/packages/mosaic-tanstack-table-core/src/filter-client.ts
+++ b/packages/mosaic-tanstack-table-core/src/filter-client.ts
@@ -2,6 +2,7 @@ import { MosaicClient } from '@uwdata/mosaic-core';
 import * as mSql from '@uwdata/mosaic-sql';
 import { createStructAccess } from './utils';
 import { SqlIdentifier } from './domain/sql-identifier';
+import { createClearClause, createValueClause } from './clause-factory';
 import type { Selection, SelectionClause } from '@uwdata/mosaic-core';
 import type { FilterInput, FilterMode } from './types';
 
@@ -66,11 +67,13 @@ export class MosaicFilter<TMode extends FilterMode> extends MosaicClient {
   public apply(value: FilterValueFor<TMode>) {
     const predicate = this.generatePredicate(value);
 
-    this.selection.update({
-      source: this,
-      value: value,
-      predicate,
-    });
+    this.selection.update(
+      createValueClause({
+        source: this,
+        value: value,
+        predicate,
+      }),
+    );
   }
 
   /**
@@ -80,11 +83,7 @@ export class MosaicFilter<TMode extends FilterMode> extends MosaicClient {
     if (this.timer) {
       clearTimeout(this.timer);
     }
-    this.selection.update({
-      source: this,
-      value: null,
-      predicate: null,
-    });
+    this.selection.update(createClearClause(this));
   }
 
   private generatePredicate(
@@ -95,8 +94,11 @@ export class MosaicFilter<TMode extends FilterMode> extends MosaicClient {
     }
 
     const colExpr = createStructAccess(SqlIdentifier.from(this.column));
+    // Widen to the full mode union so the switch stays exhaustive: adding a
+    // new FilterInput mode is a compile-driven change here.
+    const mode: FilterMode = this.mode;
 
-    switch (this.mode) {
+    switch (mode) {
       case 'TEXT': {
         return mSql.sql`${colExpr} ILIKE ${mSql.literal('%' + value + '%')}`;
       }
@@ -148,8 +150,16 @@ export class MosaicFilter<TMode extends FilterMode> extends MosaicClient {
         return null;
       }
 
-      default:
+      case 'CONDITION': {
+        // CONDITION filters are resolved by the filter-builder / table filter
+        // strategies, not by this controller.
         return null;
+      }
+
+      default: {
+        const exhaustive: never = mode;
+        return exhaustive;
+      }
     }
   }
 }

--- a/packages/mosaic-tanstack-table-core/src/filter-registry.ts
+++ b/packages/mosaic-tanstack-table-core/src/filter-registry.ts
@@ -2,6 +2,7 @@ import * as mSql from '@uwdata/mosaic-sql';
 import { Store } from '@tanstack/store';
 import { SqlIdentifier } from './domain/sql-identifier';
 import { createStructAccess } from './utils';
+import { createClearClause, createValueClause } from './clause-factory';
 import type {
   ClauseSource,
   Selection,
@@ -321,11 +322,13 @@ export class MosaicFilterRegistry {
       // Filter out the specific item
       const nextVal = currentVal.filter((item) => item.id !== filter.subId);
 
-      filter.selection.update({
-        source: filter.sourceObject,
-        value: nextVal,
-        predicate: null,
-      });
+      filter.selection.update(
+        createValueClause({
+          source: filter.sourceObject,
+          value: nextVal,
+          predicate: null,
+        }),
+      );
     } else if (
       filter.subId &&
       Array.isArray(filter.selection.value) &&
@@ -335,18 +338,16 @@ export class MosaicFilterRegistry {
         (item) => !Object.is(item, filter.value),
       );
 
-      filter.selection.update({
-        source: filter.sourceObject,
-        value: nextVal.length > 0 ? nextVal : null,
-        predicate: buildScalarSelectionPredicate(filter.sourceId, nextVal),
-      });
+      filter.selection.update(
+        createValueClause({
+          source: filter.sourceObject,
+          value: nextVal.length > 0 ? nextVal : null,
+          predicate: buildScalarSelectionPredicate(filter.sourceId, nextVal),
+        }),
+      );
     } else {
       // Standard clearing
-      filter.selection.update({
-        source: filter.sourceObject,
-        value: null,
-        predicate: null,
-      });
+      filter.selection.update(createClearClause(filter.sourceObject));
     }
   }
 

--- a/packages/mosaic-tanstack-table-core/src/index.ts
+++ b/packages/mosaic-tanstack-table-core/src/index.ts
@@ -8,6 +8,7 @@ export {
 export * from './facet-menu';
 export * from './filter-client';
 export * from './condition-predicate';
+export * from './clause-factory';
 export * from './aggregation-bridge';
 export * from './types/index';
 export * from './logger';

--- a/packages/mosaic-tanstack-table-core/src/index.ts
+++ b/packages/mosaic-tanstack-table-core/src/index.ts
@@ -8,6 +8,7 @@ export {
 export * from './facet-menu';
 export * from './filter-client';
 export * from './condition-predicate';
+export * from './subquery-predicate';
 export * from './clause-factory';
 export * from './aggregation-bridge';
 export * from './types/index';

--- a/packages/mosaic-tanstack-table-core/src/input-core/select-input-core.ts
+++ b/packages/mosaic-tanstack-table-core/src/input-core/select-input-core.ts
@@ -3,6 +3,7 @@ import * as mSql from '@uwdata/mosaic-sql';
 import { applyRoutedFilters, routeFilter } from '../query/filter-routing';
 import { createStructAccess } from '../utils';
 import { SqlIdentifier } from '../domain/sql-identifier';
+import { createValueClause } from '../clause-factory';
 import { BaseInputCore } from './base-input-core';
 import { isScalarParamTarget, isSelectionTarget } from './guards';
 import { normalizeSelectOptions } from './options';
@@ -381,24 +382,24 @@ export class SelectInputCore<T = unknown> extends BaseInputCore<
     const outputValue = this.#createOutputValue(value);
 
     if (!field || outputValue === null) {
-      return {
+      return createValueClause({
         source: this,
         value: null,
         predicate: null,
         meta: { type: 'point' },
-      };
+      });
     }
 
     const columnExpr = createStructAccess(SqlIdentifier.from(field));
     const values = Array.isArray(outputValue) ? outputValue : [outputValue];
 
     if (values.length === 0) {
-      return {
+      return createValueClause({
         source: this,
         value: null,
         predicate: null,
         meta: { type: 'point' },
-      };
+      });
     }
 
     const predicate = this.config.listMatch
@@ -408,13 +409,13 @@ export class SelectInputCore<T = unknown> extends BaseInputCore<
           values.map((item) => mSql.literal(item)),
         );
 
-    return {
+    return createValueClause({
       source: this,
       clients: new Set([this]),
       value: outputValue,
       predicate,
       meta: { type: 'point' },
-    };
+    });
   }
 
   #bindExternalOutput(): void {

--- a/packages/mosaic-tanstack-table-core/src/internal/data-table/grouped-controller.ts
+++ b/packages/mosaic-tanstack-table-core/src/internal/data-table/grouped-controller.ts
@@ -11,6 +11,7 @@ import {
 import { GROUP_ID_SEPARATOR } from '../../grouped/types';
 import { createMosaicFeature } from '../../feature';
 import { functionalUpdate } from '../../utils';
+import { createClearClause } from '../../clause-factory';
 
 import type { MosaicDataTable } from '../../data-table';
 import type { MosaicDataTableStore, PrimitiveSqlValue } from '../../types';
@@ -283,11 +284,7 @@ export class GroupedTableController<
       return;
     }
 
-    selection.update({
-      source: this.client,
-      value: null,
-      predicate: null,
-    });
+    selection.update(createClearClause(this.client));
   }
 
   async #loadChildrenIfNeeded(rowId: string): Promise<void> {

--- a/packages/mosaic-tanstack-table-core/src/internal/data-table/store.ts
+++ b/packages/mosaic-tanstack-table-core/src/internal/data-table/store.ts
@@ -40,6 +40,7 @@ export function createInitialDataTableStore<
     totalRows: undefined,
     columnDefs: options.columns ?? [],
     _facetsUpdateCount: 0,
+    _lastQuery: undefined,
     _grouped: createInitialGroupedState<TData, TValue>(),
   };
 }

--- a/packages/mosaic-tanstack-table-core/src/selection-manager.ts
+++ b/packages/mosaic-tanstack-table-core/src/selection-manager.ts
@@ -2,6 +2,7 @@ import * as mSql from '@uwdata/mosaic-sql';
 import { clausePoint, clausePoints } from '@uwdata/mosaic-core';
 import { createStructAccess } from './utils';
 import { SqlIdentifier } from './domain/sql-identifier';
+import { createValueClause } from './clause-factory';
 import type {
   MosaicClient,
   Selection,
@@ -224,14 +225,16 @@ export class MosaicSelectionManager<
       this.selection.reset(staleClauses);
     }
 
-    this.selection.update({
-      source: this.client,
-      // Critical: Exclude self from the filter so menus/tables don't filter themselves empty
-      clients: new Set([this.client]),
-      value: clause.value,
-      predicate: clause.predicate,
-      meta: clause.meta,
-    });
+    this.selection.update(
+      createValueClause({
+        source: this.client,
+        // Critical: Exclude self from the filter so menus/tables don't filter themselves empty
+        clients: new Set([this.client]),
+        value: clause.value,
+        predicate: clause.predicate,
+        meta: clause.meta,
+      }),
+    );
   }
 
   private createPointPredicate(

--- a/packages/mosaic-tanstack-table-core/src/subquery-predicate.ts
+++ b/packages/mosaic-tanstack-table-core/src/subquery-predicate.ts
@@ -1,0 +1,82 @@
+/**
+ * Subquery membership predicates: `column [NOT] IN (SELECT ...)`.
+ *
+ * Built on mosaic-sql's `InOpNode` + `ScalarSubqueryNode` (the canonical,
+ * upstream-tested path for IN-subqueries). Selection clauses carrying these
+ * predicates must be constructed with `createSubqueryClause` so they never
+ * carry optimizer `meta` (see clause-factory.ts).
+ *
+ * Note that Mosaic's `filterPushdown` does not rewrite table references
+ * inside scalar subqueries: a subquery predicate is NOT constrained by other
+ * Selection clauses. Callers that need the subquery to react to sibling
+ * filters must rebuild the predicate when those change (the filter-builder
+ * does this via the runtime `context` Selection).
+ */
+import * as mSql from '@uwdata/mosaic-sql';
+import { createStructAccess } from './utils';
+import { SqlIdentifier } from './domain/sql-identifier';
+
+import type { ExprNode, Query } from '@uwdata/mosaic-sql';
+
+/**
+ * What a subquery factory may return:
+ * - a mosaic-sql `Query` -> `column IN (<query>)`
+ * - `{ query, negate: true }` -> `NOT (column IN (<query>))`
+ * - `null` -> no predicate (the filter is cleared / inactive)
+ */
+export type SubqueryFilterQuery =
+  | Query
+  | { query: Query; negate?: boolean }
+  | null;
+
+export interface BuildSubqueryPredicateOptions {
+  /** The outer column (or struct path "a.b") tested for membership. */
+  column: string | SqlIdentifier;
+  /** The membership subquery. Should select a single column. */
+  query: Query;
+  /** When true, generates `NOT (column IN (...))`. */
+  negate?: boolean;
+}
+
+/**
+ * Builds a `column [NOT] IN (SELECT ...)` membership predicate.
+ */
+export function buildSubqueryPredicate(
+  options: BuildSubqueryPredicateOptions,
+): ExprNode {
+  const { column, query, negate = false } = options;
+  const columnAccessor =
+    typeof column === 'string' ? SqlIdentifier.from(column) : column;
+  const columnExpr = createStructAccess(columnAccessor);
+
+  const predicate = new mSql.InOpNode(
+    columnExpr,
+    new mSql.ScalarSubqueryNode(query),
+  );
+
+  return negate ? mSql.not(predicate) : predicate;
+}
+
+/**
+ * Normalizes a subquery factory result to `{ query, negate }`, or `null`
+ * when the factory opted out of producing a filter.
+ */
+export function normalizeSubqueryFilterQuery(
+  result: SubqueryFilterQuery | undefined,
+): { query: Query; negate: boolean } | null {
+  if (result === null || result === undefined) {
+    return null;
+  }
+
+  if (result instanceof mSql.Query) {
+    return {
+      query: result,
+      negate: false,
+    };
+  }
+
+  return {
+    query: result.query,
+    negate: result.negate ?? false,
+  };
+}

--- a/packages/mosaic-tanstack-table-core/src/types/general.ts
+++ b/packages/mosaic-tanstack-table-core/src/types/general.ts
@@ -440,6 +440,17 @@ export type MosaicDataTableStore<TData extends RowData, TValue = unknown> = {
   totalRows: number | undefined;
   tableOptions: SubsetTableOptions<TData>;
   _facetsUpdateCount: number;
+  /**
+   * The SQL of the most recent main query submitted to the coordinator,
+   * stringified right before execution. Covers the flat table query only
+   * (not pinned-row, sidecar/facet, or grouped child queries).
+   *
+   * @internal Debug affordance for surfacing executed SQL in development
+   * tooling and examples. Not part of the supported public API.
+   * @experimental May change shape or be removed in any release without a
+   * major version bump; do not build product features on it.
+   */
+  _lastQuery: string | undefined;
   /** Grouped-mode state. Only meaningful when `groupBy` is active. */
   _grouped: {
     /** Expanded state for the tree. */

--- a/packages/mosaic-tanstack-table-core/src/types/general.ts
+++ b/packages/mosaic-tanstack-table-core/src/types/general.ts
@@ -242,6 +242,16 @@ export type FilterInput =
       value?: ConditionValue | null;
       valueTo?: ConditionComparableValue | null;
       dataType?: 'string' | 'number' | 'date' | 'boolean';
+    }
+  | {
+      /**
+       * Subquery membership filter: `column [NOT] IN (SELECT ...)`. The
+       * value is an app-defined parameter object handed to a subquery
+       * factory (e.g. `MosaicFilterOptions.subquery`); it is never used for
+       * SQL generation directly.
+       */
+      mode: 'SUBQUERY';
+      value: unknown;
     };
 
 export type FilterMode = FilterInput['mode'];

--- a/packages/mosaic-tanstack-table-core/tests/clause-factory.test.ts
+++ b/packages/mosaic-tanstack-table-core/tests/clause-factory.test.ts
@@ -1,0 +1,74 @@
+import { Selection } from '@uwdata/mosaic-core';
+import * as mSql from '@uwdata/mosaic-sql';
+import { describe, expect, test } from 'vitest';
+
+import { createClearClause, createValueClause } from '../src/clause-factory';
+
+function createSource(id: string) {
+  return { id };
+}
+
+describe('clause-factory', () => {
+  test('createValueClause preserves the full clause shape', () => {
+    const source = createSource('value-clause');
+    const clients = new Set<never>();
+    const predicate = mSql.eq(mSql.column('a'), mSql.literal(1));
+
+    const clause = createValueClause({
+      source,
+      clients,
+      value: [1],
+      predicate,
+      meta: { type: 'point' },
+    });
+
+    expect(clause).toEqual({
+      source,
+      clients,
+      value: [1],
+      predicate,
+      meta: { type: 'point' },
+    });
+  });
+
+  test('createValueClause leaves clients and meta undefined when omitted', () => {
+    const source = createSource('bare-value-clause');
+    const predicate = mSql.eq(mSql.column('a'), mSql.literal(1));
+
+    const clause = createValueClause({ source, value: 1, predicate });
+
+    expect(clause.clients).toBeUndefined();
+    expect(clause.meta).toBeUndefined();
+  });
+
+  test('createClearClause produces a null value and predicate', () => {
+    const source = createSource('clear-clause');
+
+    expect(createClearClause(source)).toEqual({
+      source,
+      clients: undefined,
+      value: null,
+      predicate: null,
+    });
+  });
+
+  test('value and clear clauses round-trip through a Selection', () => {
+    const selection = Selection.intersect();
+    const source = createSource('round-trip');
+
+    selection.update(
+      createValueClause({
+        source,
+        value: 'x',
+        predicate: mSql.eq(mSql.column('a'), mSql.literal('x')),
+      }),
+    );
+
+    expect(selection.clauses).toHaveLength(1);
+    expect(selection.valueFor(source)).toBe('x');
+
+    selection.update(createClearClause(source));
+
+    expect(selection.clauses).toHaveLength(0);
+  });
+});

--- a/packages/mosaic-tanstack-table-core/tests/clause-factory.test.ts
+++ b/packages/mosaic-tanstack-table-core/tests/clause-factory.test.ts
@@ -2,7 +2,12 @@ import { Selection } from '@uwdata/mosaic-core';
 import * as mSql from '@uwdata/mosaic-sql';
 import { describe, expect, test } from 'vitest';
 
-import { createClearClause, createValueClause } from '../src/clause-factory';
+import {
+  createClearClause,
+  createSubqueryClause,
+  createValueClause,
+} from '../src/clause-factory';
+import { buildSubqueryPredicate } from '../src/subquery-predicate';
 
 function createSource(id: string) {
   return { id };
@@ -39,6 +44,28 @@ describe('clause-factory', () => {
 
     expect(clause.clients).toBeUndefined();
     expect(clause.meta).toBeUndefined();
+  });
+
+  test('createSubqueryClause never carries optimizer meta', () => {
+    const source = createSource('subquery-clause');
+    const predicate = buildSubqueryPredicate({
+      column: 'question',
+      query: mSql.Query.select('question').from('data'),
+    });
+
+    const clause = createSubqueryClause({
+      source,
+      value: { threshold: 100 },
+      predicate,
+    });
+
+    expect(clause).toEqual({
+      source,
+      clients: undefined,
+      value: { threshold: 100 },
+      predicate,
+    });
+    expect('meta' in clause).toBe(false);
   });
 
   test('createClearClause produces a null value and predicate', () => {

--- a/packages/mosaic-tanstack-table-core/tests/data-table.test.ts
+++ b/packages/mosaic-tanstack-table-core/tests/data-table.test.ts
@@ -584,6 +584,32 @@ describe('MosaicDataTable characterization', () => {
     ).toBe(true);
   });
 
+  test('records the executed main query SQL on the internal _lastQuery store field', async () => {
+    const { client, coordinator } = createFlatClient();
+
+    coordinator.enqueueResponse(
+      'FROM "athletes"',
+      createArrowTable([
+        { id: '1', name: 'Alice', age: 31, country: 'NZ', status: 'active' },
+      ]),
+    );
+
+    expect(client.store.state._lastQuery).toBeUndefined();
+
+    client.connect();
+    await client.pending;
+
+    await waitFor(() => {
+      const lastQuery = client.store.state._lastQuery;
+      expect(lastQuery).toBeDefined();
+      expect(lastQuery).toContain('FROM "athletes"');
+      // Matches the SQL the coordinator actually received.
+      expect(coordinator.requestLog.some(({ sql }) => sql === lastQuery)).toBe(
+        true,
+      );
+    });
+  });
+
   test('resets pagination and requeries when an external filter selection changes', async () => {
     const filterBy = new Selection();
     const { client, coordinator } = createFlatClient({ filterBy });

--- a/packages/mosaic-tanstack-table-core/tests/filter-builder.test.ts
+++ b/packages/mosaic-tanstack-table-core/tests/filter-builder.test.ts
@@ -242,6 +242,42 @@ describe('filter-builder helpers', () => {
     });
   });
 
+  test('stored values with unsupported modes are not coerced into condition values', () => {
+    // Forward-compat: stored values written by future filter families (e.g.
+    // subquery-backed filters) must hydrate as "empty", never as a condition.
+    const futureStoredValue = {
+      mode: 'SUBQUERY',
+      operator: 'in',
+      value: { threshold: 100 },
+      filterId: textDefinition.id,
+      scopeId: 'scope',
+    };
+
+    expect(
+      normalizeFilterBindingState(textDefinition, futureStoredValue),
+    ).toEqual(createEmptyFilterBindingState(textDefinition));
+  });
+
+  test('clauses storing unsupported modes read back as uncommitted state', () => {
+    const runtime = createRuntime(textDefinition);
+
+    runtime.selection.update({
+      source: createFilterBuilderSource(runtime),
+      value: {
+        mode: 'SUBQUERY',
+        operator: 'in',
+        value: { threshold: 100 },
+        filterId: runtime.definition.id,
+        scopeId: runtime.scopeId,
+      },
+      predicate: getTestPredicate(),
+    });
+
+    expect(readFilterSelectionState(runtime)).toEqual(
+      createEmptyFilterBindingState(textDefinition),
+    );
+  });
+
   test.each<
     [
       string,

--- a/packages/mosaic-tanstack-table-core/tests/filter-builder.test.ts
+++ b/packages/mosaic-tanstack-table-core/tests/filter-builder.test.ts
@@ -7,6 +7,7 @@ import {
   FilterBindingController,
   MULTISELECT_ARRAY_CONDITIONS,
   MULTISELECT_SCALAR_CONDITIONS,
+  NUMBER_CONDITIONS,
   NUMBER_RANGE_CONDITIONS,
   SELECT_CONDITIONS,
   TEXT_CONDITIONS,
@@ -16,6 +17,7 @@ import {
   getFacetSelectedValues,
   normalizeFilterBindingState,
   readFilterSelectionState,
+  reapplyCommittedFilterSelection,
 } from '../src/filter-builder';
 
 import type {
@@ -243,10 +245,10 @@ describe('filter-builder helpers', () => {
   });
 
   test('stored values with unsupported modes are not coerced into condition values', () => {
-    // Forward-compat: stored values written by future filter families (e.g.
-    // subquery-backed filters) must hydrate as "empty", never as a condition.
+    // Forward-compat: stored values written by future filter families must
+    // hydrate as "empty", never as a condition.
     const futureStoredValue = {
-      mode: 'SUBQUERY',
+      mode: 'FUTURE_MODE',
       operator: 'in',
       value: { threshold: 100 },
       filterId: textDefinition.id,
@@ -264,7 +266,7 @@ describe('filter-builder helpers', () => {
     runtime.selection.update({
       source: createFilterBuilderSource(runtime),
       value: {
-        mode: 'SUBQUERY',
+        mode: 'FUTURE_MODE',
         operator: 'in',
         value: { threshold: 100 },
         filterId: runtime.definition.id,
@@ -575,6 +577,225 @@ describe('filter-builder helpers', () => {
     expect(readFilterSelectionState(runtime)).toEqual(
       createEmptyFilterBindingState(textDefinition),
     );
+  });
+});
+
+const subqueryDefinition: FilterDefinition = {
+  id: 'popular',
+  label: 'Popular questions',
+  column: 'question',
+  valueKind: 'number',
+  operators: [NUMBER_CONDITIONS.GTE],
+  defaultOperator: NUMBER_CONDITIONS.GTE,
+  dataType: 'number',
+  subquery: ({ state, contextPredicate }) => {
+    if (state.value === null || state.value === undefined) {
+      return null;
+    }
+
+    const query = mSql.Query.select('question')
+      .from('data')
+      .groupby('question')
+      .having(mSql.gte(mSql.count(), Number(state.value)));
+
+    if (contextPredicate) {
+      query.where(contextPredicate);
+    }
+
+    return query;
+  },
+};
+
+describe('subquery filters', () => {
+  test('apply publishes an IN-subquery predicate with a SUBQUERY stored value', () => {
+    const runtime = createRuntime(subqueryDefinition);
+
+    applyFilterSelection(runtime, {
+      operator: NUMBER_CONDITIONS.GTE,
+      value: 100,
+      valueTo: null,
+    });
+
+    expect(getPredicateText(runtime)).toBe(
+      '("question" IN (SELECT "question" FROM "data" GROUP BY "question" HAVING (count(*) >= 100)))',
+    );
+
+    const [clause] = runtime.selection.clauses;
+    expect(clause?.value).toMatchObject({
+      mode: 'SUBQUERY',
+      operator: NUMBER_CONDITIONS.GTE,
+      value: 100,
+      filterId: subqueryDefinition.id,
+    });
+    expect(clause?.meta).toBeUndefined();
+  });
+
+  test('committed subquery state reads back and clears like value filters', () => {
+    const runtime = createRuntime(subqueryDefinition);
+
+    applyFilterSelection(runtime, {
+      operator: NUMBER_CONDITIONS.GTE,
+      value: 3,
+      valueTo: null,
+    });
+
+    expect(readFilterSelectionState(runtime)).toEqual({
+      operator: NUMBER_CONDITIONS.GTE,
+      value: 3,
+      valueTo: null,
+    });
+
+    clearFilterSelection(runtime);
+    expect(runtime.selection.clauses).toHaveLength(0);
+  });
+
+  test('empty values clear the clause instead of invoking the factory', () => {
+    const runtime = createRuntime(subqueryDefinition);
+
+    applyFilterSelection(runtime, {
+      operator: NUMBER_CONDITIONS.GTE,
+      value: 2,
+      valueTo: null,
+    });
+    applyFilterSelection(runtime, {
+      operator: NUMBER_CONDITIONS.GTE,
+      value: null,
+      valueTo: null,
+    });
+
+    expect(runtime.selection.clauses).toHaveLength(0);
+  });
+
+  test('persisted state rebuilds the same predicate through the factory', () => {
+    const runtime = createRuntime(subqueryDefinition);
+    applyFilterSelection(runtime, {
+      operator: NUMBER_CONDITIONS.GTE,
+      value: 5,
+      valueTo: null,
+    });
+
+    // Simulate persister round-trip: JSON-serialize the stored clause value.
+    const persisted = JSON.parse(
+      JSON.stringify(runtime.selection.clauses[0]?.value),
+    );
+
+    const rehydrated = createRuntime(subqueryDefinition);
+    applyFilterSelection(
+      rehydrated,
+      normalizeFilterBindingState(subqueryDefinition, persisted),
+    );
+
+    expect(getPredicateText(rehydrated)).toBe(getPredicateText(runtime));
+  });
+
+  test("factories receive sibling context and exclude the filter's own clause", () => {
+    const context = Selection.intersect();
+    const runtime: FilterRuntime = {
+      ...createRuntime(subqueryDefinition),
+      context,
+    };
+
+    context.update({
+      source: createForeignSource('country-filter'),
+      value: 'NZL',
+      predicate: mSql.eq(mSql.column('country'), mSql.literal('NZL')),
+    });
+
+    applyFilterSelection(runtime, {
+      operator: NUMBER_CONDITIONS.GTE,
+      value: 2,
+      valueTo: null,
+    });
+
+    expect(getPredicateText(runtime)).toContain('WHERE ("country" = \'NZL\')');
+
+    // A context mirroring the filter's own clause contributes nothing.
+    const selfBase = createRuntime(subqueryDefinition);
+    const selfRuntime: FilterRuntime = {
+      ...selfBase,
+      context: selfBase.selection,
+    };
+
+    applyFilterSelection(selfRuntime, {
+      operator: NUMBER_CONDITIONS.GTE,
+      value: 2,
+      valueTo: null,
+    });
+
+    expect(getPredicateText(selfRuntime)).not.toContain('WHERE');
+
+    // Reapplying with the own clause now present must not embed it either.
+    expect(reapplyCommittedFilterSelection(selfRuntime)).toBe(false);
+    expect(getPredicateText(selfRuntime)).not.toContain('WHERE');
+  });
+
+  test('reapplyCommittedFilterSelection republishes only when the predicate changed', () => {
+    const context = Selection.intersect();
+    const runtime: FilterRuntime = {
+      ...createRuntime(subqueryDefinition),
+      context,
+    };
+
+    applyFilterSelection(runtime, {
+      operator: NUMBER_CONDITIONS.GTE,
+      value: 2,
+      valueTo: null,
+    });
+    expect(getPredicateText(runtime)).not.toContain('NZL');
+
+    // No context change -> no republish.
+    expect(reapplyCommittedFilterSelection(runtime)).toBe(false);
+
+    context.update({
+      source: createForeignSource('country-filter'),
+      value: 'NZL',
+      predicate: mSql.eq(mSql.column('country'), mSql.literal('NZL')),
+    });
+
+    expect(reapplyCommittedFilterSelection(runtime)).toBe(true);
+    expect(getPredicateText(runtime)).toContain("'NZL'");
+
+    // Converged -> further reapplies are no-ops (loop guard).
+    expect(reapplyCommittedFilterSelection(runtime)).toBe(false);
+  });
+
+  test('reapplyCommittedFilterSelection ignores filters without committed state', () => {
+    const runtime: FilterRuntime = {
+      ...createRuntime(subqueryDefinition),
+      context: Selection.intersect(),
+    };
+
+    expect(reapplyCommittedFilterSelection(runtime)).toBe(false);
+    expect(runtime.selection.clauses).toHaveLength(0);
+  });
+
+  test('FilterBindingController rebuilds committed subquery predicates on context changes', async () => {
+    const context = Selection.intersect();
+    const runtime: FilterRuntime = {
+      ...createRuntime(subqueryDefinition),
+      context,
+    };
+    const controller = new FilterBindingController(runtime);
+    controller.connect();
+
+    applyFilterSelection(runtime, {
+      operator: NUMBER_CONDITIONS.GTE,
+      value: 2,
+      valueTo: null,
+    });
+
+    context.update({
+      source: createForeignSource('country-filter'),
+      value: 'NZL',
+      predicate: mSql.eq(mSql.column('country'), mSql.literal('NZL')),
+    });
+
+    for (let i = 0; i < 10 && !getPredicateText(runtime).includes('NZL'); i++) {
+      await flushMicrotask();
+    }
+
+    expect(getPredicateText(runtime)).toContain("'NZL'");
+    controller.dispose();
   });
 });
 

--- a/packages/mosaic-tanstack-table-core/tests/filter-builder.test.ts
+++ b/packages/mosaic-tanstack-table-core/tests/filter-builder.test.ts
@@ -769,6 +769,55 @@ describe('subquery filters', () => {
     expect(runtime.selection.clauses).toHaveLength(0);
   });
 
+  test('reapplyCommittedFilterSelection terminates when its republish relays back through the scope context', () => {
+    // Mirror the production topology: the filter's own selection relays its
+    // clauses into a shared scope context, and a listener on that context
+    // rebuilds the subquery whenever sibling filters change. Mosaic relays an
+    // update to derived selections *before* committing its own value, so the
+    // republish re-enters this listener synchronously while
+    // `runtime.selection.clauses` still reports the stale predicate — which
+    // previously caused unbounded recursion.
+    const scopeContext = Selection.intersect();
+    const runtime: FilterRuntime = {
+      ...createRuntime(subqueryDefinition),
+      context: scopeContext,
+    };
+
+    // Relay the filter selection into the scope context, exactly as
+    // `useFilterScopeContext` wires it via Mosaic's `_relay`.
+    (runtime.selection as unknown as { _relay: Set<Selection> })._relay.add(
+      scopeContext,
+    );
+
+    applyFilterSelection(runtime, {
+      operator: NUMBER_CONDITIONS.GTE,
+      value: 2,
+      valueTo: null,
+    });
+
+    let listenerCalls = 0;
+    scopeContext.addEventListener('value', () => {
+      listenerCalls += 1;
+      if (listenerCalls > 50) {
+        throw new Error('reapply listener did not converge');
+      }
+
+      reapplyCommittedFilterSelection(runtime);
+    });
+
+    // A sibling filter publishes into the scope context, driving the rebuild.
+    expect(() => {
+      scopeContext.update({
+        source: createForeignSource('country-filter'),
+        value: 'NZL',
+        predicate: mSql.eq(mSql.column('country'), mSql.literal('NZL')),
+      });
+    }).not.toThrow();
+
+    // The rebuilt predicate embeds the sibling context and the loop settled.
+    expect(getPredicateText(runtime)).toContain("'NZL'");
+  });
+
   test('FilterBindingController rebuilds committed subquery predicates on context changes', async () => {
     const context = Selection.intersect();
     const runtime: FilterRuntime = {

--- a/packages/mosaic-tanstack-table-core/tests/filter-client.test.ts
+++ b/packages/mosaic-tanstack-table-core/tests/filter-client.test.ts
@@ -1,0 +1,87 @@
+import { Selection } from '@uwdata/mosaic-core';
+import * as mSql from '@uwdata/mosaic-sql';
+import { describe, expect, test } from 'vitest';
+
+import { MosaicFilter } from '../src/filter-client';
+
+function popularQuestions(threshold: number) {
+  return mSql.Query.select('question')
+    .from('data')
+    .groupby('question')
+    .having(mSql.gte(mSql.count(), threshold));
+}
+
+function getPredicateText(selection: Selection) {
+  return selection.predicate(null)?.toString() ?? '';
+}
+
+describe('MosaicFilter SUBQUERY mode', () => {
+  test('apply publishes an IN-subquery predicate without optimizer meta', () => {
+    const selection = Selection.intersect();
+    const filter = new MosaicFilter({
+      selection,
+      column: 'question',
+      mode: 'SUBQUERY',
+      subquery: (value) =>
+        value === null ? null : popularQuestions(Number(value)),
+    });
+
+    filter.apply(100);
+
+    expect(getPredicateText(selection)).toBe(
+      '("question" IN (SELECT "question" FROM "data" GROUP BY "question" HAVING (count(*) >= 100)))',
+    );
+    expect(selection.clauses[0]?.meta).toBeUndefined();
+  });
+
+  test('factories can negate the membership predicate', () => {
+    const selection = Selection.intersect();
+    const filter = new MosaicFilter({
+      selection,
+      column: 'question',
+      mode: 'SUBQUERY',
+      subquery: (value) =>
+        value === null
+          ? null
+          : { query: popularQuestions(Number(value)), negate: true },
+    });
+
+    filter.apply(3);
+
+    expect(getPredicateText(selection)).toContain('NOT ("question" IN');
+  });
+
+  test('null factory results and dispose clear the clause', () => {
+    const selection = Selection.intersect();
+    const filter = new MosaicFilter({
+      selection,
+      column: 'question',
+      mode: 'SUBQUERY',
+      subquery: (value) =>
+        value === null ? null : popularQuestions(Number(value)),
+    });
+
+    filter.apply(2);
+    expect(selection.clauses).toHaveLength(1);
+
+    filter.apply(null);
+    expect(selection.clauses).toHaveLength(0);
+
+    filter.apply(2);
+    filter.dispose();
+    expect(selection.clauses).toHaveLength(0);
+  });
+
+  test('value modes still publish literal-value predicates', () => {
+    const selection = Selection.intersect();
+    const filter = new MosaicFilter({
+      selection,
+      column: 'name',
+      mode: 'TEXT',
+    });
+
+    filter.apply('ali');
+
+    expect(getPredicateText(selection)).toBe('"name" ILIKE \'%ali%\'');
+  });
+});

--- a/packages/mosaic-tanstack-table-core/tests/subquery-predicate.test.ts
+++ b/packages/mosaic-tanstack-table-core/tests/subquery-predicate.test.ts
@@ -1,0 +1,77 @@
+import * as mSql from '@uwdata/mosaic-sql';
+import { describe, expect, test } from 'vitest';
+
+import {
+  buildSubqueryPredicate,
+  normalizeSubqueryFilterQuery,
+} from '../src/subquery-predicate';
+
+function popularQuestions(threshold: number) {
+  return mSql.Query.select('question')
+    .from('data')
+    .groupby('question')
+    .having(mSql.gte(mSql.count(), threshold));
+}
+
+describe('buildSubqueryPredicate', () => {
+  test('builds an IN membership predicate over a scalar subquery', () => {
+    const predicate = buildSubqueryPredicate({
+      column: 'question',
+      query: popularQuestions(100),
+    });
+
+    expect(String(predicate)).toBe(
+      '("question" IN (SELECT "question" FROM "data" GROUP BY "question" HAVING (count(*) >= 100)))',
+    );
+  });
+
+  test('negate wraps the membership predicate in NOT', () => {
+    const predicate = buildSubqueryPredicate({
+      column: 'question',
+      query: popularQuestions(3),
+      negate: true,
+    });
+
+    expect(String(predicate)).toBe(
+      '(NOT ("question" IN (SELECT "question" FROM "data" GROUP BY "question" HAVING (count(*) >= 3))))',
+    );
+  });
+
+  test('supports struct paths for the outer column', () => {
+    const predicate = buildSubqueryPredicate({
+      column: 'payload.question',
+      query: mSql.Query.select('question').from('data'),
+    });
+
+    expect(String(predicate)).toContain('"payload"');
+    expect(String(predicate)).toContain('IN (SELECT "question" FROM "data")');
+  });
+});
+
+describe('normalizeSubqueryFilterQuery', () => {
+  test('passes through bare queries without negation', () => {
+    const query = popularQuestions(2);
+
+    expect(normalizeSubqueryFilterQuery(query)).toEqual({
+      query,
+      negate: false,
+    });
+  });
+
+  test('unwraps object results and defaults negate to false', () => {
+    const query = popularQuestions(2);
+
+    expect(normalizeSubqueryFilterQuery({ query })).toEqual({
+      query,
+      negate: false,
+    });
+    expect(normalizeSubqueryFilterQuery({ query, negate: true })).toEqual({
+      query,
+      negate: true,
+    });
+  });
+
+  test('returns null for empty results', () => {
+    expect(normalizeSubqueryFilterQuery(null)).toBeNull();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,14 +31,14 @@ catalogs:
       specifier: ^25.0.8
       version: 25.0.9
     '@uwdata/mosaic-core':
-      specifier: ^0.24.3
-      version: 0.24.3
+      specifier: ^0.27.0
+      version: 0.27.0
     '@uwdata/mosaic-sql':
-      specifier: ^0.24.3
-      version: 0.24.3
+      specifier: ^0.27.0
+      version: 0.27.0
     '@uwdata/vgplot':
-      specifier: ^0.24.3
-      version: 0.24.3
+      specifier: ^0.27.0
+      version: 0.27.0
     '@vitejs/plugin-react':
       specifier: ^6.0.1
       version: 6.0.1
@@ -93,16 +93,16 @@ importers:
         version: 0.4.0(@typescript-eslint/utils@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
       '@tanstack/vite-config':
         specifier: 'catalog:'
-        version: 0.5.2(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))
+        version: 0.5.2(@types/node@25.0.9)(typescript@5.9.3)(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))
       '@uwdata/mosaic-core':
         specifier: 'catalog:'
-        version: 0.24.3
+        version: 0.27.0
       '@uwdata/mosaic-sql':
         specifier: 'catalog:'
-        version: 0.24.3
+        version: 0.27.0
       '@uwdata/vgplot':
         specifier: 'catalog:'
-        version: 0.24.3
+        version: 0.27.0
       eslint:
         specifier: 'catalog:'
         version: 10.2.1(jiti@2.6.1)
@@ -132,10 +132,10 @@ importers:
         version: 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: 'catalog:'
-        version: 8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)
+        version: 8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@types/node@25.0.9)(jsdom@29.1.0)(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))
+        version: 4.1.5(@types/node@25.0.9)(jsdom@29.1.0)(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))
 
   examples/react/trimmed:
     dependencies:
@@ -168,13 +168,13 @@ importers:
         version: 0.8.0
       '@uwdata/mosaic-core':
         specifier: 'catalog:'
-        version: 0.24.3
+        version: 0.27.0
       '@uwdata/mosaic-sql':
         specifier: 'catalog:'
-        version: 0.24.3
+        version: 0.27.0
       '@uwdata/vgplot':
         specifier: 'catalog:'
-        version: 0.24.3
+        version: 0.27.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -214,7 +214,7 @@ importers:
         version: 1.59.1
       '@tailwindcss/vite':
         specifier: ^4.1.17
-        version: 4.1.18(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))
+        version: 4.1.18(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))
       '@types/d3':
         specifier: ^7.4.3
         version: 7.4.3
@@ -229,7 +229,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))
+        version: 6.0.1(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -241,7 +241,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)
+        version: 8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)
 
   packages/mosaic-tanstack-react-table:
     dependencies:
@@ -275,13 +275,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@uwdata/mosaic-core':
         specifier: 'catalog:'
-        version: 0.24.3
+        version: 0.27.0
       '@uwdata/mosaic-sql':
         specifier: 'catalog:'
-        version: 0.24.3
+        version: 0.27.0
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))
+        version: 6.0.1(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))
       eslint:
         specifier: 'catalog:'
         version: 10.2.1(jiti@2.6.1)
@@ -306,10 +306,10 @@ importers:
     devDependencies:
       '@uwdata/mosaic-core':
         specifier: 'catalog:'
-        version: 0.24.3
+        version: 0.27.0
       '@uwdata/mosaic-sql':
         specifier: 'catalog:'
-        version: 0.24.3
+        version: 0.27.0
       eslint:
         specifier: 'catalog:'
         version: 10.2.1(jiti@2.6.1)
@@ -337,10 +337,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@uwdata/mosaic-core':
         specifier: 'catalog:'
-        version: 0.24.3
+        version: 0.27.0
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))
+        version: 6.0.1(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))
       eslint:
         specifier: 'catalog:'
         version: 10.2.1(jiti@2.6.1)
@@ -358,7 +358,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)
+        version: 8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)
 
 packages:
 
@@ -549,8 +549,8 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@duckdb/duckdb-wasm@1.33.1-dev42.0':
-    resolution: {integrity: sha512-SvF2lx2LZ3Mee0BkUgIoYp9hQDP5gzqzCSnG7MRrp9UkzNXUrLR448kN+WwUxjxMTSnTWWlUzbBQC0rD/h0gDg==}
+  '@duckdb/duckdb-wasm@1.33.1-dev45.0':
+    resolution: {integrity: sha512-ETlrjhiGQzNdaOhpro/Y9u/RCcK+iyuczLy7uOn0kG5Mqlj8C+gTuhBXjs4JpK9ocdUgr3oT8zYYIbUnFD9AYA==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -578,162 +578,6 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
-
-  '@esbuild/aix-ppc64@0.27.2':
-    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.27.2':
-    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.2':
-    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.2':
-    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.27.2':
-    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.2':
-    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.27.2':
-    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.2':
-    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.27.2':
-    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.2':
-    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.27.2':
-    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.2':
-    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.27.2':
-    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.2':
-    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.27.2':
-    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.2':
-    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.27.2':
-    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.2':
-    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.2':
-    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.2':
-    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.27.2':
-    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.2':
-    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.2':
-    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -945,21 +789,25 @@ packages:
     resolution: {integrity: sha512-GdgPYMfbijBRFJs1absL/9QdSNLsTAGdyKykDf9CaVxEMZ92VB+pncpX9Vn/ZBCSeeWTLF+bSK3UM5v+loIObQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.7.1':
     resolution: {integrity: sha512-HyBgPtY1hyNTk8683nt7F29jh3lVdS/zul9vS0NgKeCSoYL3GRM3nLoTPynoHUxyVP/tWYOE3ymvnk92qYwL4Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.7.1':
     resolution: {integrity: sha512-bQBgRiEsanNvKcDOjVAUPjvcp0iDLofYYUL2af2iuCDxreLOej+J6MeA5bWTLNly5ly1d4voKGTqa+OsouVyLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.1':
     resolution: {integrity: sha512-gcco2GjcAztF/fRcAgFxtWxrWDnQdNmPaAN9FTt1+qQ9RUSLvdL8bQxKx4Kd9N9T+gXPlrWhMkBkKbbV09+X1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.7.1':
     resolution: {integrity: sha512-IT9oEn0YQ83iPH7666aoPyTRsUzBIBJdBLMXeLX4I60fHPXWhUSGpfiLtIsgU2OfeOVb9hU9idwNh1wc4u9rWQ==}
@@ -1331,36 +1179,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -1399,131 +1253,6 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
-
-  '@rollup/rollup-android-arm-eabi@4.55.1':
-    resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.55.1':
-    resolution: {integrity: sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-darwin-arm64@4.55.1':
-    resolution: {integrity: sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.55.1':
-    resolution: {integrity: sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-freebsd-arm64@4.55.1':
-    resolution: {integrity: sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.55.1':
-    resolution: {integrity: sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.55.1':
-    resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.55.1':
-    resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-gnu@4.55.1':
-    resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.55.1':
-    resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loong64-gnu@4.55.1':
-    resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loong64-musl@4.55.1':
-    resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.55.1':
-    resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-ppc64-musl@4.55.1':
-    resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.55.1':
-    resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-musl@4.55.1':
-    resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-s390x-gnu@4.55.1':
-    resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
-    cpu: [s390x]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-gnu@4.55.1':
-    resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.55.1':
-    resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-openbsd-x64@4.55.1':
-    resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.55.1':
-    resolution: {integrity: sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rollup/rollup-win32-arm64-msvc@4.55.1':
-    resolution: {integrity: sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.55.1':
-    resolution: {integrity: sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.55.1':
-    resolution: {integrity: sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.55.1':
-    resolution: {integrity: sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==}
-    cpu: [x64]
-    os: [win32]
 
   '@rushstack/node-core-library@5.7.0':
     resolution: {integrity: sha512-Ff9Cz/YlWu9ce4dmqNBZpA45AEya04XaBFIjV7xTVeEf+y/kTjEasmozqFELXlNG4ROdevss75JrrZ5WgufDkQ==}
@@ -1597,24 +1326,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1984,41 +1717,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2040,23 +1781,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@uwdata/flechette@2.4.0':
-    resolution: {integrity: sha512-cwxeYWe2iua4zPUopiqhYXkxaQWr0GK4Kbak7i0zemo3sgmNJ3IE+pNi6XD1dOK7q50SEXTLwieP5JycG6D56A==}
+  '@uwdata/flechette@2.5.0':
+    resolution: {integrity: sha512-NSB9xIPVsxpEcnEvtLfbvH/tEqZWiD4bfdz/yBUAUBEe0Z0C3zmA/Y4GOCsLZe4ChxiHaedFBZzVdUxQ+NVcMA==}
 
-  '@uwdata/mosaic-core@0.24.3':
-    resolution: {integrity: sha512-pyA06srwSal123cq5FsYAOVYASHcWppDw0KhMdZ52wkG9hfKGnKl5atiPbDnRaPSsV0MS/nL6BKjlhUiQsnypw==}
+  '@uwdata/mosaic-core@0.27.0':
+    resolution: {integrity: sha512-7BwsBYYImMaAYD4vytp62j/MQ34zd5UtS13l5EL4gXbgspNnYa8qNtyRt/MwhhWstdw7XbyXPv2p6Lk6eNeNBQ==}
 
-  '@uwdata/mosaic-inputs@0.24.3':
-    resolution: {integrity: sha512-w+Iz15sj7nWz+kMnvWmtkvH0ADmj0dT/FqYqg6OIPmet4mKTnxiKnGspKdzdf99sTqZBQHlzBWf3x+J9bXSEPA==}
+  '@uwdata/mosaic-inputs@0.27.0':
+    resolution: {integrity: sha512-RKTs+pZoNi39wbWWpjqnpZgxWJbdV22bX2ynECXhbOSqujP9BKxADms6x5Cxce6hqS0Vz/OurdcvjoN3+RX0+w==}
 
-  '@uwdata/mosaic-plot@0.24.3':
-    resolution: {integrity: sha512-4F38VBFG/uBx760cazOWJG8qfUDN7tvjf5hP6E5zZRWfhzgndLJrSCbwTNfc7pmeMG/btsttSMTfk6vbC1gXPA==}
+  '@uwdata/mosaic-plot@0.27.0':
+    resolution: {integrity: sha512-Caa+ry5tKH01gf1tYFAZbZiFBBGUui9bDvulxu0Jr7ZV6y1a0sD7Uu1nZmt2wiJDxJhF9M9sokK8tLPyO9vPLg==}
 
-  '@uwdata/mosaic-sql@0.24.3':
-    resolution: {integrity: sha512-PSsSy1PqFGXFBMzsLqzloP+/LuWHSWQIOrzlfGm+682q8/yZ49lQ9FnEFKa62rw7aZMSZ/Ra9a46LllMUG1r9w==}
+  '@uwdata/mosaic-sql@0.27.0':
+    resolution: {integrity: sha512-o/z1ux24y4ciIs/b9onMcjJ4gMCFp97CehmzAaIdz+nv3r4H1gTNLkYHKW8AYY+ey3ChNkEtNXA/aArKilRlZg==}
 
-  '@uwdata/vgplot@0.24.3':
-    resolution: {integrity: sha512-YBVbD7SYTy+P2tv0wvFd9EG7MJ+TFHSYoFgsr4jLBwp2n6TjFagjx2slKf3TitjQ1zGGJDiSGdt8Bz3fBHNuEQ==}
+  '@uwdata/vgplot@0.27.0':
+    resolution: {integrity: sha512-7RTB/PPWremI9uQZZ7Xap0SivNfjWic9ZHB2bBhFYSM2wBEQtPEfikwbJNnG8RiBtht8FS74W+yW2rmfEXAxdg==}
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -2634,11 +2375,6 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
-
-  esbuild@0.27.2:
-    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -3226,48 +2962,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3701,11 +3445,6 @@ packages:
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  rollup@4.55.1:
-    resolution: {integrity: sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -4235,11 +3974,6 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -4571,7 +4305,7 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@duckdb/duckdb-wasm@1.33.1-dev42.0':
+  '@duckdb/duckdb-wasm@1.33.1-dev45.0':
     dependencies:
       apache-arrow: 17.0.0
       qs: 6.15.1
@@ -4616,84 +4350,6 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
-    optional: true
-
-  '@esbuild/aix-ppc64@0.27.2':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/android-arm@0.27.2':
-    optional: true
-
-  '@esbuild/android-x64@0.27.2':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.2':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.2':
-    optional: true
-
-  '@esbuild/linux-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.27.2':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.2':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.2':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.2':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1(jiti@2.6.1))':
@@ -5325,88 +4981,11 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
-  '@rollup/pluginutils@5.3.0(rollup@4.55.1)':
+  '@rollup/pluginutils@5.3.0':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
-    optionalDependencies:
-      rollup: 4.55.1
-
-  '@rollup/rollup-android-arm-eabi@4.55.1':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.55.1':
-    optional: true
-
-  '@rollup/rollup-darwin-arm64@4.55.1':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.55.1':
-    optional: true
-
-  '@rollup/rollup-freebsd-arm64@4.55.1':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.55.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.55.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.55.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-gnu@4.55.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.55.1':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-gnu@4.55.1':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.55.1':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-gnu@4.55.1':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.55.1':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.55.1':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.55.1':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.55.1':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.55.1':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.55.1':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.55.1':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.55.1':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.55.1':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.55.1':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.55.1':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.55.1':
-    optional: true
 
   '@rushstack/node-core-library@5.7.0(@types/node@25.0.9)':
     dependencies:
@@ -5519,12 +5098,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.1.18(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)
 
   '@tanstack/eslint-config@0.4.0(@typescript-eslint/utils@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -5576,12 +5155,12 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.18': {}
 
-  '@tanstack/vite-config@0.5.2(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))':
+  '@tanstack/vite-config@0.5.2(@types/node@25.0.9)(typescript@5.9.3)(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))':
     dependencies:
-      vite: 8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)
-      vite-plugin-dts: 4.2.3(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))
-      vite-plugin-externalize-deps: 0.10.0(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))
-      vite-tsconfig-paths: 6.1.1(typescript@5.9.3)(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))
+      vite: 8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)
+      vite-plugin-dts: 4.2.3(@types/node@25.0.9)(typescript@5.9.3)(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))
+      vite-plugin-externalize-deps: 0.10.0(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))
+      vite-tsconfig-paths: 6.1.1(typescript@5.9.3)(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -5966,40 +5545,40 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@uwdata/flechette@2.4.0': {}
+  '@uwdata/flechette@2.5.0': {}
 
-  '@uwdata/mosaic-core@0.24.3':
+  '@uwdata/mosaic-core@0.27.0':
     dependencies:
-      '@duckdb/duckdb-wasm': 1.33.1-dev42.0
-      '@uwdata/flechette': 2.4.0
-      '@uwdata/mosaic-sql': 0.24.3
+      '@duckdb/duckdb-wasm': 1.33.1-dev45.0
+      '@uwdata/flechette': 2.5.0
+      '@uwdata/mosaic-sql': 0.27.0
 
-  '@uwdata/mosaic-inputs@0.24.3':
+  '@uwdata/mosaic-inputs@0.27.0':
     dependencies:
-      '@uwdata/mosaic-core': 0.24.3
-      '@uwdata/mosaic-sql': 0.24.3
+      '@uwdata/mosaic-core': 0.27.0
+      '@uwdata/mosaic-sql': 0.27.0
 
-  '@uwdata/mosaic-plot@0.24.3':
+  '@uwdata/mosaic-plot@0.27.0':
     dependencies:
       '@observablehq/plot': 0.6.17
-      '@uwdata/flechette': 2.4.0
-      '@uwdata/mosaic-core': 0.24.3
-      '@uwdata/mosaic-sql': 0.24.3
+      '@uwdata/flechette': 2.5.0
+      '@uwdata/mosaic-core': 0.27.0
+      '@uwdata/mosaic-sql': 0.27.0
       d3: 7.9.0
 
-  '@uwdata/mosaic-sql@0.24.3': {}
+  '@uwdata/mosaic-sql@0.27.0': {}
 
-  '@uwdata/vgplot@0.24.3':
+  '@uwdata/vgplot@0.27.0':
     dependencies:
-      '@uwdata/mosaic-core': 0.24.3
-      '@uwdata/mosaic-inputs': 0.24.3
-      '@uwdata/mosaic-plot': 0.24.3
-      '@uwdata/mosaic-sql': 0.24.3
+      '@uwdata/mosaic-core': 0.27.0
+      '@uwdata/mosaic-inputs': 0.27.0
+      '@uwdata/mosaic-plot': 0.27.0
+      '@uwdata/mosaic-sql': 0.27.0
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -6010,13 +5589,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -6587,36 +6166,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-
-  esbuild@0.27.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.2
-      '@esbuild/android-arm': 0.27.2
-      '@esbuild/android-arm64': 0.27.2
-      '@esbuild/android-x64': 0.27.2
-      '@esbuild/darwin-arm64': 0.27.2
-      '@esbuild/darwin-x64': 0.27.2
-      '@esbuild/freebsd-arm64': 0.27.2
-      '@esbuild/freebsd-x64': 0.27.2
-      '@esbuild/linux-arm': 0.27.2
-      '@esbuild/linux-arm64': 0.27.2
-      '@esbuild/linux-ia32': 0.27.2
-      '@esbuild/linux-loong64': 0.27.2
-      '@esbuild/linux-mips64el': 0.27.2
-      '@esbuild/linux-ppc64': 0.27.2
-      '@esbuild/linux-riscv64': 0.27.2
-      '@esbuild/linux-s390x': 0.27.2
-      '@esbuild/linux-x64': 0.27.2
-      '@esbuild/netbsd-arm64': 0.27.2
-      '@esbuild/netbsd-x64': 0.27.2
-      '@esbuild/openbsd-arm64': 0.27.2
-      '@esbuild/openbsd-x64': 0.27.2
-      '@esbuild/openharmony-arm64': 0.27.2
-      '@esbuild/sunos-x64': 0.27.2
-      '@esbuild/win32-arm64': 0.27.2
-      '@esbuild/win32-ia32': 0.27.2
-      '@esbuild/win32-x64': 0.27.2
-    optional: true
 
   escalade@3.2.0: {}
 
@@ -7751,38 +7300,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
-  rollup@4.55.1:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.55.1
-      '@rollup/rollup-android-arm64': 4.55.1
-      '@rollup/rollup-darwin-arm64': 4.55.1
-      '@rollup/rollup-darwin-x64': 4.55.1
-      '@rollup/rollup-freebsd-arm64': 4.55.1
-      '@rollup/rollup-freebsd-x64': 4.55.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.55.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.55.1
-      '@rollup/rollup-linux-arm64-gnu': 4.55.1
-      '@rollup/rollup-linux-arm64-musl': 4.55.1
-      '@rollup/rollup-linux-loong64-gnu': 4.55.1
-      '@rollup/rollup-linux-loong64-musl': 4.55.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.55.1
-      '@rollup/rollup-linux-ppc64-musl': 4.55.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.55.1
-      '@rollup/rollup-linux-riscv64-musl': 4.55.1
-      '@rollup/rollup-linux-s390x-gnu': 4.55.1
-      '@rollup/rollup-linux-x64-gnu': 4.55.1
-      '@rollup/rollup-linux-x64-musl': 4.55.1
-      '@rollup/rollup-openbsd-x64': 4.55.1
-      '@rollup/rollup-openharmony-arm64': 4.55.1
-      '@rollup/rollup-win32-arm64-msvc': 4.55.1
-      '@rollup/rollup-win32-ia32-msvc': 4.55.1
-      '@rollup/rollup-win32-x64-gnu': 4.55.1
-      '@rollup/rollup-win32-x64-msvc': 4.55.1
-      fsevents: 2.3.3
-    optional: true
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -8082,10 +7599,10 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-plugin-dts@4.2.3(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)):
+  vite-plugin-dts@4.2.3(@types/node@25.0.9)(typescript@5.9.3)(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)):
     dependencies:
       '@microsoft/api-extractor': 7.47.7(@types/node@25.0.9)
-      '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
+      '@rollup/pluginutils': 5.3.0
       '@volar/typescript': 2.4.27
       '@vue/language-core': 2.1.6(typescript@5.9.3)
       compare-versions: 6.1.1
@@ -8095,27 +7612,27 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.9.3
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-externalize-deps@0.10.0(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)):
+  vite-plugin-externalize-deps@0.10.0(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)):
     dependencies:
-      vite: 8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)
 
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)):
+  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2):
+  vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -8124,15 +7641,14 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.0.9
-      esbuild: 0.27.2
       fsevents: 2.3.3
       jiti: 2.6.1
-      yaml: 2.8.2
+      yaml: 2.8.0
 
-  vitest@4.1.5(@types/node@25.0.9)(jsdom@29.1.0)(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)):
+  vitest@4.1.5(@types/node@25.0.9)(jsdom@29.1.0)(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -8149,7 +7665,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.10(@types/node@25.0.9)(jiti@2.6.1)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.9
@@ -8230,9 +7746,6 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@2.8.0: {}
-
-  yaml@2.8.2:
-    optional: true
 
   yargs-parser@21.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,9 +11,9 @@ catalog:
   '@tanstack/table-core': ^8.17.3
   '@tanstack/vite-config': ^0.5.2
   '@types/node': ^25.0.8
-  '@uwdata/mosaic-core': ^0.24.3
-  '@uwdata/mosaic-sql': ^0.24.3
-  '@uwdata/vgplot': ^0.24.3
+  '@uwdata/mosaic-core': ^0.27.0
+  '@uwdata/mosaic-sql': ^0.27.0
+  '@uwdata/vgplot': ^0.27.0
   '@vitejs/plugin-react': ^6.0.1
   eslint: ^10.2.1
   eslint-plugin-react-hooks: ^7.1.1
@@ -37,6 +37,8 @@ preferWorkspacePackages: true
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - '@nozzleio/*'
+  - '@uwdata/mosaic-*'
+  - '@uwdata/vgplot'
 
 overrides:
   '@nozzleio/mosaic-tanstack-table-core': 'workspace:*'


### PR DESCRIPTION
Adds subquery membership filters — `column [NOT] IN (SELECT ...)` — across the adapter stack, plus the supporting refactors and example showcases. Verified against `@uwdata/mosaic-*` v0.27.0.

## Changes

- **Upgrade** the Mosaic packages to `^0.27.0`.
- **Carve-out refactor** (no behaviour change): a single clause-construction module, exhaustive filter dispatch, and forward-compatible stored filter values, creating the branch points subqueries plug into.
- **Subquery filters**:
  - `buildSubqueryPredicate` / `createSubqueryClause` in the core (subquery clauses never carry optimizer `meta`).
  - Filter-builder definitions accept a `subquery` factory; persisted state stays serializable and hydration rebuilds the predicate. Runtimes accept a `context` selection so factories can embed sibling-filter predicates, with automatic convergent rebuilds.
  - `MosaicFilter` / `useMosaicTableFilter` gain a `SUBQUERY` mode.
- **`_lastQuery`** debug field on the table store (`@internal` / `@experimental`) exposing the executed main-query SQL.
- **Examples** (`filter-builder`, `nozzle-paa`): declarative and imperative subquery filters, a SERP-appearances widget filter that drives both a `HAVING` clause and a cross-filtering membership subquery, per-widget SQL footers, and column-fit layout fixes.

Follow-up work is tracked in #151.

## API notes

- `MosaicFilterOptions` is now a conditional type (breaks interface-extension consumers).
- `FilterMode` / `FilterInput` unions gain `'SUBQUERY'`.
